### PR TITLE
Disable `repo-checkout` in `govulncheck` action for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,5 @@ jobs:
           go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11
           gosec ./...
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          repo-checkout: false


### PR DESCRIPTION
## Description

Updates `actions/checkout` from v4.2.2 to v6.0.1 and fixes compatibility issue with `govulncheck-action`.

The `govulncheck-action` performs its own internal checkout which conflicts with `actions/checkout` v6.x, causing duplicate Authorization headers and HTTP 400 errors. Fixed by setting `repo-checkout: false` on `govulncheck-action` since we already checkout with `actions/checkout`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [x] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes #6

## Testing

- [ ] Ran `go test ./...` locally
- [ ] Tested manually with a DataHub instance
- [ ] Added new tests for changes (if applicable)

CI workflow changes - tested by running the workflow.

## Checklist

- [x] My code follows the project's style guidelines (`golangci-lint run`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

Before fix - Security Scan failing with:
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/txn2/mcp-datahub/': The requested URL returned error: 400
```
