### PR TITLE
Revamp README and documentation for clarity and improved usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project are documented in [GitHub Releases](https://github.com/txn2/mcp-datahub/releases).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-- Initial project structure
-- DataHub GraphQL client
-- MCP tools: search, get_entity, get_schema, get_lineage, get_queries, get_glossary_term, list_tags, list_domains
-- Toolkit pattern for composable MCP servers
-- CI/CD workflows
-- Documentation site
-
-## [0.1.0] - TBD
-
-### Added
-- Initial release
-- Core DataHub integration via GraphQL API
-- 8 MCP tools for data catalog exploration
-- Composable library architecture
-- Multi-platform binaries (Linux, macOS, Windows)
-- Docker images
-- Homebrew formula
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
- Simplify installation and usage instructions with two distinct paths: standalone MCP server and composable Go library.
- Refactor examples for better readability and update links to reference external documentation.
- Consolidate and streamline related content under "Configuration" and "Related Projects" sections.
- Update project sponsorship details and changelog link.

## Description

Restructures README.md to clearly present mcp-datahub as both an MCP server and composable Go library. Adds prominent links to the official documentation site and streamlines content to avoid duplication with the docs.

Key changes:
- "Two Ways to Use" section showing standalone server vs library usage
- Dedicated "Combining with mcp-trino" section for the ecosystem story
- Links to https://mcp-datahub.txn2.com for detailed docs
- Updated footer with Deasil Works, Inc. sponsorship
- CHANGELOG.md now points to GitHub Releases

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [x] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

N/A - Documentation improvement

## Testing

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a DataHub instance
- [ ] Added new tests for changes (if applicable)

Documentation-only changes verified by:
- All tests pass (71 tests)
- Lint passes (0 issues)
- Build succeeds

## Checklist

- [x] My code follows the project's style guidelines (`golangci-lint run`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

N/A - Documentation changes only
