### PR TITLE
Revamp `README.md` with updated installation instructions, usage exam…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,103 +7,84 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/txn2/mcp-datahub/badge)](https://scorecard.dev/viewer/?uri=github.com/txn2/mcp-datahub)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
-A **composable Go library** for building custom MCP servers that integrate [DataHub](https://datahubproject.io/) metadata capabilities. Part of the txn2 MCP toolkit ecosystem.
+An MCP server and composable Go library that connects AI assistants to [DataHub](https://datahubproject.io/) metadata catalogs. Search datasets, explore schemas, trace lineage, and access glossary terms and domains.
 
-## Why This Library?
+**[Documentation](https://mcp-datahub.txn2.com)** | **[Installation](https://mcp-datahub.txn2.com/server/installation/)** | **[Library Docs](https://mcp-datahub.txn2.com/library/)**
 
-**This is not a replacement for the official DataHub MCP server.** Instead, mcp-datahub is designed as a building block for organizations that need to:
+## Two Ways to Use
 
-- **Combine multiple data tools** into a unified MCP server (DataHub + Trino + dbt + custom tools)
-- **Add enterprise features** like multi-tenant isolation, custom auth, or audit logging
-- **Build domain-specific assistants** that understand your particular data stack
-- **Extend functionality** with middleware, hooks, and custom integrations
+### 1. Standalone MCP Server
 
-The included CLI binary (`mcp-datahub`) serves as a **reference implementation** demonstrating the library's capabilities. It's fully functional as a standalone DataHub MCP server, but the real power comes from composition.
+Install and connect to Claude Desktop, Cursor, or any MCP client:
 
-## Composable Architecture
+```bash
+# Homebrew (macOS)
+brew install txn2/tap/mcp-datahub
 
-### Combining Multiple Toolkits
+# Go install
+go install github.com/txn2/mcp-datahub/cmd/mcp-datahub@latest
+```
 
-Build a unified MCP server that gives AI assistants access to your entire data stack:
+```json
+{
+  "mcpServers": {
+    "datahub": {
+      "command": "/opt/homebrew/bin/mcp-datahub",
+      "env": {
+        "DATAHUB_URL": "https://datahub.example.com",
+        "DATAHUB_TOKEN": "your_token"
+      }
+    }
+  }
+}
+```
+
+### 2. Composable Go Library
+
+Import into your own MCP server for custom authentication, tenant isolation, and audit logging:
 
 ```go
-package main
-
 import (
-    "context"
-    "log"
+    "github.com/txn2/mcp-datahub/pkg/client"
+    "github.com/txn2/mcp-datahub/pkg/tools"
+)
 
-    "github.com/modelcontextprotocol/go-sdk/mcp"
+// Create client and register tools with your MCP server
+datahubClient, _ := client.NewFromEnv()
+defer datahubClient.Close()
 
-    // DataHub for metadata and lineage
+toolkit := tools.NewToolkit(datahubClient, tools.Config{})
+toolkit.RegisterAll(yourMCPServer)
+```
+
+See the [library documentation](https://mcp-datahub.txn2.com/library/) for middleware, selective tool registration, and enterprise patterns.
+
+## Combining with mcp-trino
+
+Build a unified data platform MCP server by combining DataHub metadata with Trino query execution:
+
+```go
+import (
     datahubClient "github.com/txn2/mcp-datahub/pkg/client"
     datahubTools "github.com/txn2/mcp-datahub/pkg/tools"
-
-    // Trino for query execution
     trinoClient "github.com/txn2/mcp-trino/pkg/client"
     trinoTools "github.com/txn2/mcp-trino/pkg/tools"
 )
 
-func main() {
-    server := mcp.NewServer(&mcp.Implementation{
-        Name:    "my-data-platform",
-        Version: "1.0.0",
-    }, nil)
+// Add DataHub tools (search, lineage, schema, glossary)
+dh, _ := datahubClient.NewFromEnv()
+datahubTools.NewToolkit(dh, datahubTools.Config{}).RegisterAll(server)
 
-    // Add DataHub tools (search, lineage, schema, glossary)
-    dh, _ := datahubClient.NewFromEnv()
-    defer dh.Close()
-    datahubTools.NewToolkit(dh, datahubTools.Config{}).RegisterAll(server)
+// Add Trino tools (query execution, catalog browsing)
+tr, _ := trinoClient.NewFromEnv()
+trinoTools.NewToolkit(tr, trinoTools.Config{}).RegisterAll(server)
 
-    // Add Trino tools (query execution, catalog browsing)
-    tr, _ := trinoClient.NewFromEnv()
-    defer tr.Close()
-    trinoTools.NewToolkit(tr, trinoTools.Config{}).RegisterAll(server)
-
-    // Now AI assistants can:
-    // - Search DataHub for tables → Get schema → Query via Trino
-    // - Explore lineage → Understand data flow → Run validation queries
-    // - Look up glossary terms → Find related datasets → Analyze data
-
-    server.Run(context.Background(), &mcp.StdioTransport{})
-}
+// AI assistants can now:
+// - Search DataHub for tables -> Get schema -> Query via Trino
+// - Explore lineage -> Understand data flow -> Run validation queries
 ```
 
-### Selective Tool Registration
-
-Register only the tools you need:
-
-```go
-toolkit := datahubTools.NewToolkit(client, config)
-
-// Register specific tools
-toolkit.Register(server,
-    datahubTools.ToolSearch,
-    datahubTools.ToolGetSchema,
-    datahubTools.ToolGetLineage,
-)
-
-// Or register all
-toolkit.RegisterAll(server)
-```
-
-### Middleware for Enterprise Features
-
-Add cross-cutting concerns without modifying tool implementations:
-
-```go
-// Audit logging middleware
-auditMiddleware := &AuditMiddleware{logger: auditLog}
-
-// Rate limiting middleware
-rateLimiter := &RateLimitMiddleware{limiter: limiter}
-
-toolkit := datahubTools.NewToolkit(client, config,
-    datahubTools.WithMiddleware(auditMiddleware),
-    datahubTools.WithMiddleware(rateLimiter),
-    datahubTools.WithToolMiddleware(datahubTools.ToolSearch, searchSpecificMiddleware),
-)
-```
+See [txn2/mcp-trino](https://github.com/txn2/mcp-trino) for the companion library.
 
 ## Available Tools
 
@@ -120,41 +101,7 @@ toolkit := datahubTools.NewToolkit(client, config,
 | `datahub_list_data_products` | List data products |
 | `datahub_get_data_product` | Get data product details (owners, domain, properties) |
 
-## Installation
-
-### As a Library (Recommended)
-
-```bash
-go get github.com/txn2/mcp-datahub
-```
-
-### Reference Implementation Binary
-
-For standalone use or testing:
-
-```bash
-# Homebrew (macOS)
-brew install txn2/tap/mcp-datahub
-
-# Go install
-go install github.com/txn2/mcp-datahub/cmd/mcp-datahub@latest
-```
-
-### Claude Desktop Configuration
-
-```json
-{
-  "mcpServers": {
-    "datahub": {
-      "command": "/opt/homebrew/bin/mcp-datahub",
-      "env": {
-        "DATAHUB_URL": "https://datahub.example.com",
-        "DATAHUB_TOKEN": "your_token"
-      }
-    }
-  }
-}
-```
+See the [tools reference](https://mcp-datahub.txn2.com/server/tools/) for detailed documentation.
 
 ## Configuration
 
@@ -166,61 +113,7 @@ go install github.com/txn2/mcp-datahub/cmd/mcp-datahub@latest
 | `DATAHUB_DEFAULT_LIMIT` | Default search limit | `10` |
 | `DATAHUB_MAX_LIMIT` | Maximum limit | `100` |
 
-## Library Usage Examples
-
-### Basic Usage
-
-```go
-import (
-    "github.com/txn2/mcp-datahub/pkg/client"
-    "github.com/txn2/mcp-datahub/pkg/tools"
-)
-
-// Create client from environment
-datahubClient, err := client.NewFromEnv()
-if err != nil {
-    log.Fatal(err)
-}
-defer datahubClient.Close()
-
-// Create toolkit and register with your MCP server
-toolkit := tools.NewToolkit(datahubClient, tools.Config{})
-toolkit.RegisterAll(yourMCPServer)
-```
-
-### Direct Client Usage
-
-Use the client directly for custom integrations:
-
-```go
-import "github.com/txn2/mcp-datahub/pkg/client"
-
-c, _ := client.New(client.Config{
-    URL:   "https://datahub.example.com",
-    Token: "your_token",
-})
-
-// Search for datasets
-results, _ := c.Search(ctx, "customer", client.WithEntityType("DATASET"), client.WithLimit(10))
-
-// Get entity details
-entity, _ := c.GetEntity(ctx, "urn:li:dataset:(urn:li:dataPlatform:postgres,mydb.users,PROD)")
-
-// Get schema
-schema, _ := c.GetSchema(ctx, datasetURN)
-
-// Get lineage
-lineage, _ := c.GetLineage(ctx, datasetURN, client.WithDirection(client.LineageDirectionUpstream))
-```
-
-### Custom MCP Server with Multiple Toolkits
-
-See [examples/combined-server](examples/combined-server) for a complete example combining DataHub with other data tools.
-
-## Related Projects
-
-- [txn2/mcp-trino](https://github.com/txn2/mcp-trino) - Composable MCP toolkit for Trino query execution
-- [DataHub](https://datahubproject.io/) - The open-source metadata platform
+See [configuration reference](https://mcp-datahub.txn2.com/server/configuration/) for all options.
 
 ## Development
 
@@ -234,6 +127,11 @@ make verify    # Run tidy, lint, and test
 make help      # Show all targets
 ```
 
+## Related Projects
+
+- [txn2/mcp-trino](https://github.com/txn2/mcp-trino) ([docs](https://mcp-trino.txn2.com)) - Composable MCP toolkit for Trino query execution
+- [DataHub](https://datahubproject.io/) - The open-source metadata platform
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -244,4 +142,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
-Open source by [Craig Johnston](https://twitter.com/cjimti)
+Open source by [Craig Johnston](https://twitter.com/cjimti), sponsored by [Deasil Works, Inc.](https://deasil.works/)


### PR DESCRIPTION
## Description

Restructures README to clearly present mcp-datahub as both a standalone MCP server and a composable Go library.

Changes:
- New opening that emphasizes both server and library use cases
- "Two Ways to Use" section with distinct paths for server vs library
- Links to official documentation site (https://mcp-datahub.txn2.com)
- Dedicated "Combining with mcp-trino" section
- Added Deasil Works, Inc. sponsorship to footer
- Removed verbose examples already covered in docs

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [x] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

N/A

## Testing

- [x] Ran `go test ./...` locally
- [ ] Tested manually with a DataHub instance
- [ ] Added new tests for changes (if applicable)

## Checklist

- [x] My code follows the project's style guidelines (`golangci-lint run`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

N/A
