### PR TITLE
Pin and add Docker GitHub Actions (`setup-qemu-action` v3.6.0, `setup…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,39 +5,78 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}  # Restrict default token permissions
 
 jobs:
   release:
-    name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write  # Required for keyless signing with Cosign
+      attestations: write  # Required for GitHub attestations
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
+          cache: true
 
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      - name: Verify and prepare Go modules
+        run: |
+          go mod download
+          go mod verify
 
-      - uses: anchore/sbom-action/download-syft@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
-      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@a930d0ac434e3182448fe678398ba5713717112a # v0.21.0
+
+      - name: Verify Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "ERROR: HOMEBREW_TAP_TOKEN secret is not set!"
+            exit 1
+          fi
+          echo "Token is set (length: ${#HOMEBREW_TAP_TOKEN} chars)"
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $HOMEBREW_TAP_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/txn2/homebrew-tap")
+          echo "API response code: $HTTP_CODE"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: Token cannot access txn2/homebrew-tap (HTTP $HTTP_CODE)"
+            exit 1
+          fi
+          echo "Token verified - can access homebrew-tap"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2.13"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Description

Fixes release workflow to match the working mcp-trino configuration. The v0.1.0 release failed due to missing syft, missing docker buildx setup, and incorrect permissions.

Changes:
- Add `permissions: {}` at top level, move permissions to job level (fixes security alerts)
- Add `attestations: write` permission for docker attestations
- Add QEMU and Docker Buildx setup steps (fixes "Attestation is not supported for the docker driver" error)
- Add Syft installation (fixes "syft: executable file not found in $PATH" error)
- Add Go module download/verify step
- Add Homebrew token verification step
- Pin goreleaser version to `~> v2.13` instead of `latest`
- Update all action SHAs to match mcp-trino

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [x] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

Fixes release workflow failures:
- https://github.com/txn2/mcp-datahub/actions/runs/21018009632 (syft not found)
- https://github.com/txn2/mcp-datahub/actions/runs/21018489071 (docker attestation error)

## Testing

- [ ] Ran `go test ./...` locally
- [ ] Tested manually with a DataHub instance
- [ ] Added new tests for changes (if applicable)

CI workflow change. Will be tested by re-running the release after merge.

## Checklist

- [x] My code follows the project's style guidelines (`golangci-lint run`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

## Screenshots/Logs (if applicable)

Error 1 (syft):
```
cataloging artifacts: syft failed: exec: "syft": executable file not found in $PATH
```

Error 2 (docker attestation):
```
ERROR: failed to build: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```
