### PR TITLE
Fix release workflow: draft until MCPB bundles uploaded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,11 @@ jobs:
             gh release upload "$GITHUB_REF_NAME" "${mcpb}.sigstore.json" --clobber
           done
 
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+
       - name: Install mcp-publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -173,6 +173,7 @@ release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
   prerelease: auto
   mode: append
+  draft: true
   footer: |
     ## Installation
 


### PR DESCRIPTION
## Summary

- GoReleaser now creates the release as a draft (`draft: true`)
- MCPB bundles and signatures are uploaded to the draft release
- Release is published (`--draft=false`) after all uploads complete

This prevents the HTTP 422 "Cannot upload assets to an immutable release" error that breaks every release.

## Test plan

- [x] Tag a new release and verify MCPB bundles upload successfully
- [x] Verify release transitions from draft to published after uploads