### PR TITLE
feat: add default icons for all tools

### DIFF
--- a/icons/datahub.svg
+++ b/icons/datahub.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1B1F3B"/>
+  <circle cx="32" cy="24" r="8" fill="none" stroke="#00BFA5" stroke-width="2.5"/>
+  <circle cx="20" cy="42" r="6" fill="none" stroke="#00BFA5" stroke-width="2.5"/>
+  <circle cx="44" cy="42" r="6" fill="none" stroke="#00BFA5" stroke-width="2.5"/>
+  <line x1="27" y1="30" x2="22" y2="37" stroke="#00BFA5" stroke-width="2"/>
+  <line x1="37" y1="30" x2="42" y2="37" stroke="#00BFA5" stroke-width="2"/>
+  <line x1="26" y1="42" x2="38" y2="42" stroke="#00BFA5" stroke-width="2"/>
+</svg>

--- a/pkg/tools/column_lineage.go
+++ b/pkg/tools/column_lineage.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerGetColumnLineageTool(server *mcp.Server, cfg *toolConf
 		Name:        string(ToolGetColumnLineage),
 		Description: t.getDescription(ToolGetColumnLineage, cfg),
 		Annotations: t.getAnnotations(ToolGetColumnLineage, cfg),
+		Icons:       t.getIcons(ToolGetColumnLineage, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetColumnLineageInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/connections.go
+++ b/pkg/tools/connections.go
@@ -39,6 +39,7 @@ func (t *Toolkit) registerListConnectionsTool(server *mcp.Server, cfg *toolConfi
 		Name:        string(ToolListConnections),
 		Description: t.getDescription(ToolListConnections, cfg),
 		Annotations: t.getAnnotations(ToolListConnections, cfg),
+		Icons:       t.getIcons(ToolListConnections, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListConnectionsInput) (*mcp.CallToolResult, *ListConnectionsOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListConnectionsOutput); ok {

--- a/pkg/tools/dataproducts.go
+++ b/pkg/tools/dataproducts.go
@@ -27,6 +27,7 @@ func (t *Toolkit) registerListDataProductsTool(server *mcp.Server, cfg *toolConf
 		Name:        string(ToolListDataProducts),
 		Description: t.getDescription(ToolListDataProducts, cfg),
 		Annotations: t.getAnnotations(ToolListDataProducts, cfg),
+		Icons:       t.getIcons(ToolListDataProducts, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListDataProductsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})
@@ -76,6 +77,7 @@ func (t *Toolkit) registerGetDataProductTool(server *mcp.Server, cfg *toolConfig
 		Name:        string(ToolGetDataProduct),
 		Description: t.getDescription(ToolGetDataProduct, cfg),
 		Annotations: t.getAnnotations(ToolGetDataProduct, cfg),
+		Icons:       t.getIcons(ToolGetDataProduct, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetDataProductInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/domains.go
+++ b/pkg/tools/domains.go
@@ -27,6 +27,7 @@ func (t *Toolkit) registerListDomainsTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolListDomains),
 		Description: t.getDescription(ToolListDomains, cfg),
 		Annotations: t.getAnnotations(ToolListDomains, cfg),
+		Icons:       t.getIcons(ToolListDomains, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListDomainsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/entity.go
+++ b/pkg/tools/entity.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerGetEntityTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolGetEntity),
 		Description: t.getDescription(ToolGetEntity, cfg),
 		Annotations: t.getAnnotations(ToolGetEntity, cfg),
+		Icons:       t.getIcons(ToolGetEntity, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetEntityInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/glossary.go
+++ b/pkg/tools/glossary.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerGetGlossaryTermTool(server *mcp.Server, cfg *toolConfi
 		Name:        string(ToolGetGlossaryTerm),
 		Description: t.getDescription(ToolGetGlossaryTerm, cfg),
 		Annotations: t.getAnnotations(ToolGetGlossaryTerm, cfg),
+		Icons:       t.getIcons(ToolGetGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetGlossaryTermInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/icons.go
+++ b/pkg/tools/icons.go
@@ -1,0 +1,34 @@
+package tools
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// defaultIcons holds the default icon for all DataHub tools.
+// Uses a GitHub-hosted SVG from the mcp-datahub repository.
+var defaultIcons = []mcp.Icon{{
+	Source:   "https://raw.githubusercontent.com/txn2/mcp-datahub/main/icons/datahub.svg",
+	MIMEType: "image/svg+xml",
+}}
+
+// DefaultIcons returns the default icons for DataHub tools.
+func DefaultIcons() []mcp.Icon {
+	return defaultIcons
+}
+
+// getIcons resolves the icons for a tool using the priority chain:
+// 1. Per-registration override (cfg.icons) — highest priority
+// 2. Toolkit-level override (t.icons) — medium priority
+// 3. Default icons — lowest priority.
+func (t *Toolkit) getIcons(name ToolName, cfg *toolConfig) []mcp.Icon {
+	// Per-registration override (highest priority)
+	if cfg != nil && cfg.icons != nil {
+		return cfg.icons
+	}
+
+	// Toolkit-level override (medium priority)
+	if icons, ok := t.icons[name]; ok {
+		return icons
+	}
+
+	// Default icons (lowest priority)
+	return defaultIcons
+}

--- a/pkg/tools/icons_test.go
+++ b/pkg/tools/icons_test.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestDefaultIcons(t *testing.T) {
+	icons := DefaultIcons()
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 default icon, got %d", len(icons))
+	}
+	if icons[0].Source == "" {
+		t.Error("default icon source should not be empty")
+	}
+	if icons[0].MIMEType != "image/svg+xml" {
+		t.Errorf("expected MIME type image/svg+xml, got %s", icons[0].MIMEType)
+	}
+}
+
+func TestGetIcons_DefaultPriority(t *testing.T) {
+	tk := newBaseToolkit(Config{})
+	icons := tk.getIcons(ToolSearch, nil)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon source, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_ToolkitOverride(t *testing.T) {
+	tk := newBaseToolkit(Config{})
+	customIcons := []mcp.Icon{{Source: "https://example.com/custom.svg", MIMEType: "image/svg+xml"}}
+	tk.icons[ToolSearch] = customIcons
+
+	// ToolSearch should get the override
+	icons := tk.getIcons(ToolSearch, nil)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != "https://example.com/custom.svg" {
+		t.Errorf("expected custom icon source, got %s", icons[0].Source)
+	}
+
+	// ToolGetEntity should get the default
+	icons = tk.getIcons(ToolGetEntity, nil)
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon source for ToolGetEntity, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_PerRegistrationOverride(t *testing.T) {
+	tk := newBaseToolkit(Config{})
+	tk.icons[ToolSearch] = []mcp.Icon{{Source: "https://example.com/toolkit.svg"}}
+
+	cfg := &toolConfig{
+		icons: []mcp.Icon{{Source: "https://example.com/registration.svg"}},
+	}
+	icons := tk.getIcons(ToolSearch, cfg)
+	if len(icons) != 1 {
+		t.Fatalf("expected 1 icon, got %d", len(icons))
+	}
+	if icons[0].Source != "https://example.com/registration.svg" {
+		t.Errorf("expected per-registration icon source, got %s", icons[0].Source)
+	}
+}
+
+func TestGetIcons_NilConfig(t *testing.T) {
+	tk := newBaseToolkit(Config{})
+	icons := tk.getIcons(ToolSearch, nil)
+	if len(icons) == 0 {
+		t.Fatal("expected default icons, got empty")
+	}
+}
+
+func TestGetIcons_EmptyToolConfig(t *testing.T) {
+	tk := newBaseToolkit(Config{})
+	cfg := &toolConfig{}
+	icons := tk.getIcons(ToolSearch, cfg)
+	if len(icons) == 0 {
+		t.Fatal("expected default icons, got empty")
+	}
+	if icons[0].Source != defaultIcons[0].Source {
+		t.Errorf("expected default icon, got %s", icons[0].Source)
+	}
+}

--- a/pkg/tools/lineage.go
+++ b/pkg/tools/lineage.go
@@ -33,6 +33,7 @@ func (t *Toolkit) registerGetLineageTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolGetLineage),
 		Description: t.getDescription(ToolGetLineage, cfg),
 		Annotations: t.getAnnotations(ToolGetLineage, cfg),
+		Icons:       t.getIcons(ToolGetLineage, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetLineageInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/options.go
+++ b/pkg/tools/options.go
@@ -41,6 +41,7 @@ type toolConfig struct {
 	middlewares []ToolMiddleware
 	description *string
 	annotations *mcp.ToolAnnotations
+	icons       []mcp.Icon
 }
 
 // ToolOption configures a single tool registration.
@@ -79,6 +80,26 @@ func WithAnnotations(anns map[ToolName]*mcp.ToolAnnotations) ToolkitOption {
 func WithAnnotation(ann *mcp.ToolAnnotations) ToolOption {
 	return func(cfg *toolConfig) {
 		cfg.annotations = ann
+	}
+}
+
+// WithIcons sets toolkit-level icon overrides for multiple tools.
+// These take priority over default icons but are overridden by
+// per-registration WithIcon options.
+func WithIcons(icons map[ToolName][]mcp.Icon) ToolkitOption {
+	return func(t *Toolkit) {
+		for name, ic := range icons {
+			t.icons[name] = ic
+		}
+	}
+}
+
+// WithIcon overrides the icons for a single tool registration.
+// This is the highest priority override, taking precedence over both
+// toolkit-level WithIcons and default icons.
+func WithIcon(icons []mcp.Icon) ToolOption {
+	return func(cfg *toolConfig) {
+		cfg.icons = icons
 	}
 }
 

--- a/pkg/tools/queries.go
+++ b/pkg/tools/queries.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerGetQueriesTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolGetQueries),
 		Description: t.getDescription(ToolGetQueries, cfg),
 		Annotations: t.getAnnotations(ToolGetQueries, cfg),
+		Icons:       t.getIcons(ToolGetQueries, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetQueriesInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerGetSchemaTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolGetSchema),
 		Description: t.getDescription(ToolGetSchema, cfg),
 		Annotations: t.getAnnotations(ToolGetSchema, cfg),
+		Icons:       t.getIcons(ToolGetSchema, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetSchemaInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -35,6 +35,7 @@ func (t *Toolkit) registerSearchTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolSearch),
 		Description: t.getDescription(ToolSearch, cfg),
 		Annotations: t.getAnnotations(ToolSearch, cfg),
+		Icons:       t.getIcons(ToolSearch, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/tags.go
+++ b/pkg/tools/tags.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerListTagsTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolListTags),
 		Description: t.getDescription(ToolListTags, cfg),
 		Annotations: t.getAnnotations(ToolListTags, cfg),
+		Icons:       t.getIcons(ToolListTags, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListTagsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -43,6 +43,9 @@ type Toolkit struct {
 	// Annotation overrides (toolkit-level, set via WithAnnotations)
 	annotations map[ToolName]*mcp.ToolAnnotations
 
+	// Icon overrides (toolkit-level, set via WithIcons)
+	icons map[ToolName][]mcp.Icon
+
 	// Internal tracking
 	registeredTools map[ToolName]bool
 }
@@ -84,6 +87,7 @@ func newBaseToolkit(cfg Config) *Toolkit {
 		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
 		descriptions:    make(map[ToolName]string),
 		annotations:     make(map[ToolName]*mcp.ToolAnnotations),
+		icons:           make(map[ToolName][]mcp.Icon),
 		registeredTools: make(map[ToolName]bool),
 	}
 }

--- a/pkg/tools/write_description.go
+++ b/pkg/tools/write_description.go
@@ -28,6 +28,7 @@ func (t *Toolkit) registerUpdateDescriptionTool(server *mcp.Server, cfg *toolCon
 		Name:        string(ToolUpdateDescription),
 		Description: t.getDescription(ToolUpdateDescription, cfg),
 		Annotations: t.getAnnotations(ToolUpdateDescription, cfg),
+		Icons:       t.getIcons(ToolUpdateDescription, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		input UpdateDescriptionInput,
 	) (*mcp.CallToolResult, *UpdateDescriptionOutput, error) {

--- a/pkg/tools/write_glossary_terms.go
+++ b/pkg/tools/write_glossary_terms.go
@@ -35,6 +35,7 @@ func (t *Toolkit) registerAddGlossaryTermTool(server *mcp.Server, cfg *toolConfi
 		Name:        string(ToolAddGlossaryTerm),
 		Description: t.getDescription(ToolAddGlossaryTerm, cfg),
 		Annotations: t.getAnnotations(ToolAddGlossaryTerm, cfg),
+		Icons:       t.getIcons(ToolAddGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddGlossaryTermInput) (*mcp.CallToolResult, *AddGlossaryTermOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddGlossaryTermOutput); ok {
@@ -59,6 +60,7 @@ func (t *Toolkit) registerRemoveGlossaryTermTool(server *mcp.Server, cfg *toolCo
 		Name:        string(ToolRemoveGlossaryTerm),
 		Description: t.getDescription(ToolRemoveGlossaryTerm, cfg),
 		Annotations: t.getAnnotations(ToolRemoveGlossaryTerm, cfg),
+		Icons:       t.getIcons(ToolRemoveGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		input RemoveGlossaryTermInput,
 	) (*mcp.CallToolResult, *RemoveGlossaryTermOutput, error) {

--- a/pkg/tools/write_links.go
+++ b/pkg/tools/write_links.go
@@ -36,6 +36,7 @@ func (t *Toolkit) registerAddLinkTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolAddLink),
 		Description: t.getDescription(ToolAddLink, cfg),
 		Annotations: t.getAnnotations(ToolAddLink, cfg),
+		Icons:       t.getIcons(ToolAddLink, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddLinkInput) (*mcp.CallToolResult, *AddLinkOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddLinkOutput); ok {
@@ -60,6 +61,7 @@ func (t *Toolkit) registerRemoveLinkTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolRemoveLink),
 		Description: t.getDescription(ToolRemoveLink, cfg),
 		Annotations: t.getAnnotations(ToolRemoveLink, cfg),
+		Icons:       t.getIcons(ToolRemoveLink, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input RemoveLinkInput) (*mcp.CallToolResult, *RemoveLinkOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*RemoveLinkOutput); ok {

--- a/pkg/tools/write_tags.go
+++ b/pkg/tools/write_tags.go
@@ -35,6 +35,7 @@ func (t *Toolkit) registerAddTagTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolAddTag),
 		Description: t.getDescription(ToolAddTag, cfg),
 		Annotations: t.getAnnotations(ToolAddTag, cfg),
+		Icons:       t.getIcons(ToolAddTag, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddTagInput) (*mcp.CallToolResult, *AddTagOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddTagOutput); ok {
@@ -59,6 +60,7 @@ func (t *Toolkit) registerRemoveTagTool(server *mcp.Server, cfg *toolConfig) {
 		Name:        string(ToolRemoveTag),
 		Description: t.getDescription(ToolRemoveTag, cfg),
 		Annotations: t.getAnnotations(ToolRemoveTag, cfg),
+		Icons:       t.getIcons(ToolRemoveTag, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input RemoveTagInput) (*mcp.CallToolResult, *RemoveTagOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*RemoveTagOutput); ok {


### PR DESCRIPTION
## Summary

- Add `Icons` field to all 19 tool registrations across 15 files (12 read tools + 7 write tools)
- Implement 3-level icon priority chain: per-registration override → toolkit-level override → built-in default (same pattern as descriptions and annotations)
- New `WithIcons()` toolkit option and `WithIcon()` tool option for consumers to customize icons
- Default icon is a DataHub-branded SVG hosted in the `icons/` directory

## Details

The MCP SDK's `mcp.Tool` struct includes an `Icons []mcp.Icon` field that surfaces visual metadata in `tools/list` responses. Clients that support icons (e.g., Claude Desktop) render these alongside tool names.

The resolution chain follows the same pattern used by `getDescription()` and `getAnnotations()`:

1. **Per-registration** (`WithIcon()` tool option) — highest priority
2. **Toolkit-level** (`WithIcons()` toolkit option) — override specific tools
3. **Built-in default** — all tools get the DataHub SVG

This allows downstream consumers (e.g., `mcp-data-platform`) to override icons via their own configuration layer.

## Tools updated

Read tools: `datahub_search`, `datahub_get_entity`, `datahub_get_schema`, `datahub_get_lineage`, `datahub_get_column_lineage`, `datahub_get_queries`, `datahub_get_glossary_term`, `datahub_get_data_product`, `datahub_list_connections`, `datahub_list_domains`, `datahub_list_tags`, `datahub_list_data_products`

Write tools: `datahub_write_description`, `datahub_write_tags` (2 registrations), `datahub_write_glossary_terms` (2 registrations), `datahub_write_links` (2 registrations)

## Files

| File | Change |
|------|--------|
| `icons/datahub.svg` | New — default DataHub tool icon |
| `pkg/tools/icons.go` | New — `getIcons()` helper + default icon constant |
| `pkg/tools/icons_test.go` | New — tests for all priority levels |
| `pkg/tools/toolkit.go` | Add `icons` map field to Toolkit struct |
| `pkg/tools/options.go` | Add `WithIcons()` toolkit option, `WithIcon()` tool option |
| 15 tool files | Add `Icons: t.getIcons(...)` to each tool registration |

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] Lint clean (`golangci-lint run ./...` — 0 issues)
- [x] New unit tests cover default icons, toolkit-level override, per-registration override, nil config, and empty config
- [ ] Manual: connect a client, call `tools/list`, verify icons appear on all 19 tool entries