### PR TITLE
fix: handle null getAspect responses, add UpdateColumnDescription

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -175,7 +175,7 @@ func (c *Client) doRequest(ctx context.Context, jsonBody []byte, result any) err
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.token)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //#nosec G704 -- URL is constructed from configured endpoint, not arbitrary user input
 	if err != nil {
 		return c.handleRequestError(ctx, err)
 	}


### PR DESCRIPTION
## Summary

- **P0 — Null JSON crash**: `getAspect()` now returns `ErrNotFound` when DataHub returns HTTP 200 with a null or empty aspect value. Previously this caused `json.Unmarshal` panics on entities where the requested aspect (e.g., `editableDatasetProperties`, `editableSchemaMetadata`, `globalTags`) had never been written. All read-modify-write operations (`UpdateDescription`, `AddTag`, `RemoveTag`, `AddGlossaryTerm`, `AddLink`) benefit from this fix since they all call `getAspect()` internally and already handle `ErrNotFound` by initializing a default struct.

- **P2 — Column-level descriptions**: Added `UpdateColumnDescription(ctx, urn, fieldPath, description)` method using read-modify-write on the `editableSchemaMetadata` aspect. This enables setting editable descriptions on individual columns/fields. The implementation preserves existing field metadata (tags, glossary terms) during updates by using `json.RawMessage` for non-description fields.

- **Housekeeping**: Added `#nosec G704` annotations on three `httpClient.Do()` calls where URLs are constructed from configured endpoints, not user input.

## Details

### Null aspect handling (`rest.go`)

DataHub's REST API can return `200 OK` with `{"value": null}` when:
- The entity exists but the specific aspect has never been explicitly written
- The entity was created via ingestion but certain editable aspects are absent

The new `isNullOrEmptyJSON()` helper detects nil, empty, whitespace-only, and `null` literal values. When detected in `getAspect()`, the function returns `ErrNotFound`, which all existing callers already handle gracefully.

### Column description writes (`write.go`)

`UpdateColumnDescription` follows the same read-modify-write pattern as `UpdateDescription`:

1. Read current `editableSchemaMetadata` via `getAspect()` (empty struct if not found)
2. Find the matching `fieldPath` entry or append a new one
3. Update the description, preserving `globalTags` and `glossaryTerms` as raw JSON
4. Write back via `postIngestProposal()`

The `editableFieldInfo` struct uses `json.RawMessage` for `GlobalTags` and `GlossaryTerms` to avoid deserializing/reserializing metadata that the caller didn't intend to modify.

## Test plan

- [x] `TestGetAspect_NullValue` — verifies null and empty value responses return `ErrNotFound`
- [x] `TestIsNullOrEmptyJSON` — table-driven: nil, empty, null literal, whitespace, valid JSON
- [x] `TestUpdateColumnDescription` — updates existing field, verifies tags preserved
- [x] `TestUpdateColumnDescription_NewField` — appends new field to existing schema
- [x] `TestUpdateColumnDescription_NoExistingAspect` — 404 on read creates new schema
- [x] `TestUpdateColumnDescription_NullAspectValue` — P0 integration: 200+null triggers default init
- [x] `TestUpdateColumnDescription_InvalidURN` — error on malformed URN
- [x] `TestUpdateColumnDescription_ServerError` — error propagation on 500
- [x] `TestReadEditableSchema_InvalidJSON` — error on unparseable aspect value
- [x] All existing tests pass, `golangci-lint` 0 issues, `gosec` 0 issues

Closes #57