### PR TITLE
feat: add write API for Query entities

### DIFF
--- a/pkg/client/queries.go
+++ b/pkg/client/queries.go
@@ -581,6 +581,60 @@ query getColumnLineage($urn: String!) {
 }
 `
 
+	// CreateQueryMutation creates a new Query entity.
+	CreateQueryMutation = `
+mutation createQuery($input: CreateQueryInput!) {
+  createQuery(input: $input) {
+    urn
+    properties {
+      name
+      description
+      source
+      statement {
+        value
+        language
+      }
+      created {
+        time
+        actor
+      }
+    }
+    subjects {
+      datasets {
+        dataset {
+          urn
+        }
+      }
+    }
+  }
+}
+`
+
+	// UpdateQueryMutation updates an existing Query entity.
+	UpdateQueryMutation = `
+mutation updateQuery($urn: String!, $input: UpdateQueryInput!) {
+  updateQuery(urn: $urn, input: $input) {
+    urn
+    properties {
+      name
+      description
+      source
+      statement {
+        value
+        language
+      }
+    }
+  }
+}
+`
+
+	// DeleteQueryMutation deletes a Query entity.
+	DeleteQueryMutation = `
+mutation deleteQuery($urn: String!) {
+  deleteQuery(urn: $urn)
+}
+`
+
 	// BatchGetSchemasQuery retrieves schemas for multiple datasets by URN.
 	BatchGetSchemasQuery = `
 query batchGetSchemas($urns: [String!]!) {

--- a/pkg/client/write_queries.go
+++ b/pkg/client/write_queries.go
@@ -1,0 +1,236 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/txn2/mcp-datahub/pkg/types"
+)
+
+// CreateQueryInput holds the parameters for creating a new Query entity.
+type CreateQueryInput struct {
+	// Name is an optional human-readable name for the query.
+	Name string
+
+	// Description is an optional description of the query.
+	Description string
+
+	// Statement is the SQL query text (required).
+	Statement string
+
+	// Language is the query language (default: "SQL").
+	Language string
+
+	// DatasetURNs are optional dataset URNs to associate with the query.
+	DatasetURNs []string
+}
+
+// UpdateQueryInput holds the parameters for updating an existing Query entity.
+type UpdateQueryInput struct {
+	// URN is the query URN (required).
+	URN string
+
+	// Name is an optional updated name. Empty string means no change.
+	Name string
+
+	// Description is an optional updated description. Empty string means no change.
+	Description string
+
+	// Statement is an optional updated SQL text. Empty string means no change.
+	Statement string
+
+	// Language is an optional updated language. Empty string means no change.
+	Language string
+
+	// DatasetURNs are optional updated dataset associations. Nil means no change.
+	DatasetURNs []string
+}
+
+// createQueryResponse is the GraphQL response shape for createQuery.
+type createQueryResponse struct {
+	CreateQuery queryEntityResponse `json:"createQuery"`
+}
+
+// updateQueryResponse is the GraphQL response shape for updateQuery.
+type updateQueryResponse struct {
+	UpdateQuery queryEntityResponse `json:"updateQuery"`
+}
+
+// deleteQueryResponse is the GraphQL response shape for deleteQuery.
+type deleteQueryResponse struct {
+	DeleteQuery bool `json:"deleteQuery"`
+}
+
+// queryEntityResponse is the nested query entity returned by mutations.
+type queryEntityResponse struct {
+	URN        string                 `json:"urn"`
+	Properties *queryPropertiesRaw    `json:"properties"`
+	Subjects   *querySubjectsRawOuter `json:"subjects"`
+}
+
+// queryPropertiesRaw maps the GraphQL QueryProperties type.
+type queryPropertiesRaw struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Source      string            `json:"source"`
+	Statement   queryStatementRaw `json:"statement"`
+	Created     *auditStampGQL    `json:"created"`
+}
+
+// queryStatementRaw maps the QueryStatement type.
+type queryStatementRaw struct {
+	Value    string `json:"value"`
+	Language string `json:"language"`
+}
+
+// auditStampGQL maps a GraphQL AuditStamp with time as int64.
+type auditStampGQL struct {
+	Time  int64  `json:"time"`
+	Actor string `json:"actor"`
+}
+
+// querySubjectsRawOuter maps the QuerySubjects type.
+type querySubjectsRawOuter struct {
+	Datasets []queryDatasetRef `json:"datasets"`
+}
+
+// queryDatasetRef maps QuerySubjects.datasets[].dataset.
+type queryDatasetRef struct {
+	Dataset struct {
+		URN string `json:"urn"`
+	} `json:"dataset"`
+}
+
+// CreateQuery creates a new Query entity in DataHub.
+func (c *Client) CreateQuery(ctx context.Context, input CreateQueryInput) (*types.Query, error) {
+	if input.Statement == "" {
+		return nil, fmt.Errorf("CreateQuery: statement is required")
+	}
+
+	lang := input.Language
+	if lang == "" {
+		lang = "SQL"
+	}
+
+	gqlInput := map[string]any{
+		"properties": map[string]any{
+			"name":        input.Name,
+			"description": input.Description,
+			"statement": map[string]any{
+				"value":    input.Statement,
+				"language": lang,
+			},
+		},
+	}
+
+	if len(input.DatasetURNs) > 0 {
+		datasets := make([]map[string]string, len(input.DatasetURNs))
+		for i, urn := range input.DatasetURNs {
+			datasets[i] = map[string]string{"datasetUrn": urn}
+		}
+		gqlInput["subjects"] = map[string]any{
+			"datasets": datasets,
+		}
+	}
+
+	variables := map[string]any{"input": gqlInput}
+
+	var resp createQueryResponse
+	if err := c.Execute(ctx, CreateQueryMutation, variables, &resp); err != nil {
+		return nil, fmt.Errorf("CreateQuery: %w", err)
+	}
+
+	return toQuery(&resp.CreateQuery), nil
+}
+
+// UpdateQuery updates an existing Query entity in DataHub.
+func (c *Client) UpdateQuery(ctx context.Context, input UpdateQueryInput) (*types.Query, error) {
+	if input.URN == "" {
+		return nil, fmt.Errorf("UpdateQuery: urn is required")
+	}
+
+	properties := map[string]any{}
+	hasProperties := false
+
+	if input.Name != "" {
+		properties["name"] = input.Name
+		hasProperties = true
+	}
+	if input.Description != "" {
+		properties["description"] = input.Description
+		hasProperties = true
+	}
+	if input.Statement != "" {
+		lang := input.Language
+		if lang == "" {
+			lang = "SQL"
+		}
+		properties["statement"] = map[string]any{
+			"value":    input.Statement,
+			"language": lang,
+		}
+		hasProperties = true
+	}
+
+	gqlInput := map[string]any{}
+	if hasProperties {
+		gqlInput["properties"] = properties
+	}
+
+	if input.DatasetURNs != nil {
+		datasets := make([]map[string]string, len(input.DatasetURNs))
+		for i, urn := range input.DatasetURNs {
+			datasets[i] = map[string]string{"datasetUrn": urn}
+		}
+		gqlInput["subjects"] = map[string]any{
+			"datasets": datasets,
+		}
+	}
+
+	variables := map[string]any{
+		"urn":   input.URN,
+		"input": gqlInput,
+	}
+
+	var resp updateQueryResponse
+	if err := c.Execute(ctx, UpdateQueryMutation, variables, &resp); err != nil {
+		return nil, fmt.Errorf("UpdateQuery: %w", err)
+	}
+
+	return toQuery(&resp.UpdateQuery), nil
+}
+
+// DeleteQuery deletes a Query entity from DataHub.
+func (c *Client) DeleteQuery(ctx context.Context, urn string) error {
+	if urn == "" {
+		return fmt.Errorf("DeleteQuery: urn is required")
+	}
+
+	variables := map[string]any{"urn": urn}
+
+	var resp deleteQueryResponse
+	if err := c.Execute(ctx, DeleteQueryMutation, variables, &resp); err != nil {
+		return fmt.Errorf("DeleteQuery: %w", err)
+	}
+
+	return nil
+}
+
+// toQuery converts a GraphQL query entity response to a types.Query.
+func toQuery(r *queryEntityResponse) *types.Query {
+	q := &types.Query{URN: r.URN}
+
+	if r.Properties != nil {
+		q.Name = r.Properties.Name
+		q.Description = r.Properties.Description
+		q.Source = r.Properties.Source
+		q.Statement = r.Properties.Statement.Value
+
+		if r.Properties.Created != nil {
+			q.CreatedBy = r.Properties.Created.Actor
+			q.Created = r.Properties.Created.Time
+		}
+	}
+
+	return q
+}

--- a/pkg/client/write_queries_test.go
+++ b/pkg/client/write_queries_test.go
@@ -1,0 +1,413 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{
+			"data": {
+				"createQuery": {
+					"urn": "urn:li:query:abc123",
+					"properties": {
+						"name": "Top Revenue",
+						"description": "Top revenue query",
+						"source": "MANUAL",
+						"statement": {
+							"value": "SELECT * FROM orders",
+							"language": "SQL"
+						},
+						"created": {
+							"time": 1700000000000,
+							"actor": "urn:li:corpuser:admin"
+						}
+					}
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	query, err := c.CreateQuery(context.Background(), CreateQueryInput{
+		Name:      "Top Revenue",
+		Statement: "SELECT * FROM orders",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if query.URN != "urn:li:query:abc123" {
+		t.Errorf("expected URN 'urn:li:query:abc123', got %q", query.URN)
+	}
+	if query.Name != "Top Revenue" {
+		t.Errorf("expected Name 'Top Revenue', got %q", query.Name)
+	}
+	if query.Statement != "SELECT * FROM orders" {
+		t.Errorf("expected Statement 'SELECT * FROM orders', got %q", query.Statement)
+	}
+	if query.Source != "MANUAL" {
+		t.Errorf("expected Source 'MANUAL', got %q", query.Source)
+	}
+	if query.CreatedBy != "urn:li:corpuser:admin" {
+		t.Errorf("expected CreatedBy 'urn:li:corpuser:admin', got %q", query.CreatedBy)
+	}
+}
+
+func TestCreateQuery_EmptyStatement(t *testing.T) {
+	c := &Client{logger: NopLogger{}}
+	_, err := c.CreateQuery(context.Background(), CreateQueryInput{})
+	if err == nil {
+		t.Fatal("expected error for empty statement")
+	}
+}
+
+func TestCreateQuery_WithDatasetURNs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		// Verify subjects are passed through
+		inputRaw, ok := req.Variables["input"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input variable")
+		}
+		subjects, ok := inputRaw["subjects"].(map[string]any)
+		if !ok {
+			t.Fatal("expected subjects in input")
+		}
+		datasets, ok := subjects["datasets"].([]any)
+		if !ok {
+			t.Fatal("expected datasets in subjects")
+		}
+		if len(datasets) != 2 {
+			t.Errorf("expected 2 datasets, got %d", len(datasets))
+		}
+
+		resp := `{
+			"data": {
+				"createQuery": {
+					"urn": "urn:li:query:with-datasets",
+					"properties": {
+						"name": "With Datasets",
+						"description": "",
+						"source": "MANUAL",
+						"statement": {"value": "SELECT 1", "language": "SQL"}
+					}
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	query, err := c.CreateQuery(context.Background(), CreateQueryInput{
+		Name:      "With Datasets",
+		Statement: "SELECT 1",
+		DatasetURNs: []string{
+			"urn:li:dataset:(urn:li:dataPlatform:hive,db.table1,PROD)",
+			"urn:li:dataset:(urn:li:dataPlatform:hive,db.table2,PROD)",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if query.URN != "urn:li:query:with-datasets" {
+		t.Errorf("unexpected URN: %q", query.URN)
+	}
+}
+
+func TestCreateQuery_DefaultLanguage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		inputRaw, ok := req.Variables["input"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input variable")
+		}
+		props, ok := inputRaw["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected properties in input")
+		}
+		stmt, ok := props["statement"].(map[string]any)
+		if !ok {
+			t.Fatal("expected statement in properties")
+		}
+		if stmt["language"] != "SQL" {
+			t.Errorf("expected default language 'SQL', got %v", stmt["language"])
+		}
+
+		resp := `{"data":{"createQuery":{"urn":"urn:li:query:lang",` +
+			`"properties":{"name":"","description":"","source":"MANUAL",` +
+			`"statement":{"value":"SELECT 1","language":"SQL"}}}}}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.CreateQuery(context.Background(), CreateQueryInput{
+		Statement: "SELECT 1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateQuery_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{"errors":[{"message":"Something went wrong"}]}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.CreateQuery(context.Background(), CreateQueryInput{
+		Statement: "SELECT 1",
+	})
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestUpdateQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{
+			"data": {
+				"updateQuery": {
+					"urn": "urn:li:query:abc123",
+					"properties": {
+						"name": "Updated Name",
+						"description": "Updated desc",
+						"source": "MANUAL",
+						"statement": {"value": "SELECT 2", "language": "SQL"}
+					}
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	query, err := c.UpdateQuery(context.Background(), UpdateQueryInput{
+		URN:       "urn:li:query:abc123",
+		Name:      "Updated Name",
+		Statement: "SELECT 2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if query.URN != "urn:li:query:abc123" {
+		t.Errorf("expected URN 'urn:li:query:abc123', got %q", query.URN)
+	}
+	if query.Name != "Updated Name" {
+		t.Errorf("expected Name 'Updated Name', got %q", query.Name)
+	}
+}
+
+func TestUpdateQuery_EmptyURN(t *testing.T) {
+	c := &Client{logger: NopLogger{}}
+	_, err := c.UpdateQuery(context.Background(), UpdateQueryInput{})
+	if err == nil {
+		t.Fatal("expected error for empty URN")
+	}
+}
+
+func TestUpdateQuery_WithDatasetURNs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		inputRaw, ok := req.Variables["input"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input variable")
+		}
+		subjects, ok := inputRaw["subjects"].(map[string]any)
+		if !ok {
+			t.Fatal("expected subjects in input")
+		}
+		datasets, ok := subjects["datasets"].([]any)
+		if !ok {
+			t.Fatal("expected datasets in subjects")
+		}
+		if len(datasets) != 1 {
+			t.Errorf("expected 1 dataset, got %d", len(datasets))
+		}
+
+		resp := `{"data":{"updateQuery":{"urn":"urn:li:query:abc123",` +
+			`"properties":{"name":"","description":"","source":"MANUAL",` +
+			`"statement":{"value":"SELECT 1","language":"SQL"}}}}}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.UpdateQuery(context.Background(), UpdateQueryInput{
+		URN:         "urn:li:query:abc123",
+		DatasetURNs: []string{"urn:li:dataset:(urn:li:dataPlatform:hive,db.table1,PROD)"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateQuery_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{"errors":[{"message":"Something went wrong"}]}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.UpdateQuery(context.Background(), UpdateQueryInput{
+		URN:       "urn:li:query:abc123",
+		Statement: "SELECT 2",
+	})
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestDeleteQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{"data":{"deleteQuery":true}}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.DeleteQuery(context.Background(), "urn:li:query:abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteQuery_EmptyURN(t *testing.T) {
+	c := &Client{logger: NopLogger{}}
+	err := c.DeleteQuery(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty URN")
+	}
+}
+
+func TestDeleteQuery_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := `{"errors":[{"message":"Something went wrong"}]}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.DeleteQuery(context.Background(), "urn:li:query:abc123")
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestToQuery_NilProperties(t *testing.T) {
+	resp := &queryEntityResponse{URN: "urn:li:query:test"}
+	q := toQuery(resp)
+	if q.URN != "urn:li:query:test" {
+		t.Errorf("expected URN 'urn:li:query:test', got %q", q.URN)
+	}
+	if q.Name != "" {
+		t.Errorf("expected empty Name, got %q", q.Name)
+	}
+}
+
+func TestToQuery_NilCreated(t *testing.T) {
+	resp := &queryEntityResponse{
+		URN: "urn:li:query:test",
+		Properties: &queryPropertiesRaw{
+			Name:   "Test",
+			Source: "MANUAL",
+			Statement: queryStatementRaw{
+				Value:    "SELECT 1",
+				Language: "SQL",
+			},
+		},
+	}
+	q := toQuery(resp)
+	if q.CreatedBy != "" {
+		t.Errorf("expected empty CreatedBy, got %q", q.CreatedBy)
+	}
+	if q.Created != 0 {
+		t.Errorf("expected Created 0, got %d", q.Created)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CreateQuery`, `UpdateQuery`, and `DeleteQuery` methods to the DataHub client using native GraphQL mutations (`createQuery`, `updateQuery`, `deleteQuery`)
- These are **client-level methods only** — no new MCP tools are introduced
- `CreateQueryInput` accepts name, description, statement, language, and optional dataset URN associations
- `UpdateQueryInput` supports partial updates (only non-empty fields are sent)
- `DeleteQuery` is included for cleanup and composability by downstream consumers

## Motivation

The client supports reading Query entities via `GetQueries()` but has no write capability. This blocks downstream features where agents discover useful query patterns and need to persist them as first-class curated queries in DataHub.

The downstream consumer ([txn2/mcp-data-platform#141](https://github.com/txn2/mcp-data-platform/issues/141)) will call these client methods internally from the `apply_knowledge` pipeline — they are not exposed as standalone MCP tools to avoid tool explosion.

## Files changed

| File | What |
|------|------|
| `pkg/client/queries.go` | Add 3 GraphQL mutation constants |
| `pkg/client/write_queries.go` | `CreateQuery`, `UpdateQuery`, `DeleteQuery` methods + input/response types |
| `pkg/client/write_queries_test.go` | 12 unit tests (success, validation, server errors, dataset associations, defaults, nil handling) |
| `pkg/client/write_integration_test.go` | 3 integration tests (create, update, delete) with `t.Cleanup` isolation |

## Design decisions

- **GraphQL mutations, not REST**: Unlike existing write methods (tags, descriptions, links) that use `ingestProposal` REST for aspect-level CRUD, Query entities are first-class entities with dedicated GraphQL mutations. The new methods use `Client.Execute()` directly.
- **No MCP tools**: The issue (#62) calls for client-level API only. The downstream platform consumes these internally via `apply_knowledge`, not as agent-facing tools.
- **Default language**: `CreateQuery` defaults to `"SQL"` when no language is specified.
- **Partial updates**: `UpdateQuery` only sends fields that are non-empty, allowing callers to update specific properties without overwriting others.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./pkg/client/` — all 12 new tests pass
- [x] `golangci-lint run` — 0 issues
- [x] Full `make lint && make test` — clean
- [ ] Integration tests (`go test -tags=integration ./pkg/client/`) require live DataHub instance

Closes #62
Unblocks [txn2/mcp-data-platform#141](https://github.com/txn2/mcp-data-platform/issues/141)

🤖 Generated with [Claude Code](https://claude.com/claude-code)