### PR TITLE
fix: align Query mutations with DataHub v1.3+ GraphQL schema

### DIFF
--- a/pkg/client/queries.go
+++ b/pkg/client/queries.go
@@ -600,10 +600,8 @@ mutation createQuery($input: CreateQueryInput!) {
       }
     }
     subjects {
-      datasets {
-        dataset {
-          urn
-        }
+      dataset {
+        urn
       }
     }
   }

--- a/pkg/client/write_queries.go
+++ b/pkg/client/write_queries.go
@@ -63,9 +63,9 @@ type deleteQueryResponse struct {
 
 // queryEntityResponse is the nested query entity returned by mutations.
 type queryEntityResponse struct {
-	URN        string                 `json:"urn"`
-	Properties *queryPropertiesRaw    `json:"properties"`
-	Subjects   *querySubjectsRawOuter `json:"subjects"`
+	URN        string              `json:"urn"`
+	Properties *queryPropertiesRaw `json:"properties"`
+	Subjects   []querySubjectRaw   `json:"subjects"`
 }
 
 // queryPropertiesRaw maps the GraphQL QueryProperties type.
@@ -89,13 +89,8 @@ type auditStampGQL struct {
 	Actor string `json:"actor"`
 }
 
-// querySubjectsRawOuter maps the QuerySubjects type.
-type querySubjectsRawOuter struct {
-	Datasets []queryDatasetRef `json:"datasets"`
-}
-
-// queryDatasetRef maps QuerySubjects.datasets[].dataset.
-type queryDatasetRef struct {
+// querySubjectRaw maps the QuerySubject type (one per subject).
+type querySubjectRaw struct {
 	Dataset struct {
 		URN string `json:"urn"`
 	} `json:"dataset"`
@@ -123,15 +118,11 @@ func (c *Client) CreateQuery(ctx context.Context, input CreateQueryInput) (*type
 		},
 	}
 
-	if len(input.DatasetURNs) > 0 {
-		datasets := make([]map[string]string, len(input.DatasetURNs))
-		for i, urn := range input.DatasetURNs {
-			datasets[i] = map[string]string{"datasetUrn": urn}
-		}
-		gqlInput["subjects"] = map[string]any{
-			"datasets": datasets,
-		}
+	subjects := make([]map[string]string, len(input.DatasetURNs))
+	for i, urn := range input.DatasetURNs {
+		subjects[i] = map[string]string{"datasetUrn": urn}
 	}
+	gqlInput["subjects"] = subjects
 
 	variables := map[string]any{"input": gqlInput}
 
@@ -178,13 +169,11 @@ func (c *Client) UpdateQuery(ctx context.Context, input UpdateQueryInput) (*type
 	}
 
 	if input.DatasetURNs != nil {
-		datasets := make([]map[string]string, len(input.DatasetURNs))
+		subjects := make([]map[string]string, len(input.DatasetURNs))
 		for i, urn := range input.DatasetURNs {
-			datasets[i] = map[string]string{"datasetUrn": urn}
+			subjects[i] = map[string]string{"datasetUrn": urn}
 		}
-		gqlInput["subjects"] = map[string]any{
-			"datasets": datasets,
-		}
+		gqlInput["subjects"] = subjects
 	}
 
 	variables := map[string]any{

--- a/pkg/client/write_queries_test.go
+++ b/pkg/client/write_queries_test.go
@@ -81,21 +81,27 @@ func TestCreateQuery_WithDatasetURNs(t *testing.T) {
 			t.Fatalf("failed to decode request: %v", err)
 		}
 
-		// Verify subjects are passed through
+		// Verify subjects are passed as a flat array
 		inputRaw, ok := req.Variables["input"].(map[string]any)
 		if !ok {
 			t.Fatal("expected input variable")
 		}
-		subjects, ok := inputRaw["subjects"].(map[string]any)
+		subjects, ok := inputRaw["subjects"].([]any)
 		if !ok {
-			t.Fatal("expected subjects in input")
+			t.Fatalf("expected subjects as array in input, got %T", inputRaw["subjects"])
 		}
-		datasets, ok := subjects["datasets"].([]any)
-		if !ok {
-			t.Fatal("expected datasets in subjects")
+		if len(subjects) != 2 {
+			t.Errorf("expected 2 subjects, got %d", len(subjects))
 		}
-		if len(datasets) != 2 {
-			t.Errorf("expected 2 datasets, got %d", len(datasets))
+		// Verify each subject has datasetUrn
+		for i, s := range subjects {
+			subj, ok := s.(map[string]any)
+			if !ok {
+				t.Fatalf("subject[%d]: expected map, got %T", i, s)
+			}
+			if _, ok := subj["datasetUrn"]; !ok {
+				t.Errorf("subject[%d]: missing datasetUrn field", i)
+			}
 		}
 
 		resp := `{
@@ -270,16 +276,12 @@ func TestUpdateQuery_WithDatasetURNs(t *testing.T) {
 		if !ok {
 			t.Fatal("expected input variable")
 		}
-		subjects, ok := inputRaw["subjects"].(map[string]any)
+		subjects, ok := inputRaw["subjects"].([]any)
 		if !ok {
-			t.Fatal("expected subjects in input")
+			t.Fatalf("expected subjects as array in input, got %T", inputRaw["subjects"])
 		}
-		datasets, ok := subjects["datasets"].([]any)
-		if !ok {
-			t.Fatal("expected datasets in subjects")
-		}
-		if len(datasets) != 1 {
-			t.Errorf("expected 1 dataset, got %d", len(datasets))
+		if len(subjects) != 1 {
+			t.Errorf("expected 1 subject, got %d", len(subjects))
 		}
 
 		resp := `{"data":{"updateQuery":{"urn":"urn:li:query:abc123",` +


### PR DESCRIPTION
## Summary

- **Fixes runtime GraphQL validation error**: `Field 'datasets' in type 'QuerySubject' is undefined` when calling `createQuery` or `updateQuery`
- **Root cause**: The Query mutation GraphQL and input format were written against a fabricated `QuerySubjects` wrapper type that doesn't exist in DataHub's actual schema
- **Aligned all three layers** (mutation text, Go input construction, Go response structs) with the [real DataHub v1.3+ GraphQL schema](https://github.com/datahub-project/datahub/blob/master/datahub-graphql-core/src/main/resources/entity.graphql)

## What changed

### 1. Response selection (`queries.go`)

```diff
 subjects {
-  datasets {
-    dataset {
-      urn
-    }
+  dataset {
+    urn
   }
 }
```

`QueryEntity.subjects` returns `[QuerySubject!]` directly. Each `QuerySubject` has a `dataset: Dataset!` field. There is no wrapping `QuerySubjects` type with a `datasets` array.

### 2. Input format (`write_queries.go`)

```diff
-gqlInput["subjects"] = map[string]any{
-    "datasets": datasets,
-}
+gqlInput["subjects"] = subjects  // flat []map[string]string
```

`CreateQueryInput.subjects` expects `[CreateQuerySubjectInput!]!` — a flat array of `{datasetUrn: String!}` objects. The old code wrapped this in a nonexistent `{"datasets": [...]}` object.

Additionally, `subjects` is now always sent (it's a required field in the schema), as an empty array `[]` when no `DatasetURNs` are provided, instead of being conditionally omitted.

### 3. Response structs (`write_queries.go`)

Removed the fabricated `querySubjectsRawOuter` wrapper struct. `queryEntityResponse.Subjects` is now `[]querySubjectRaw` matching the flat `[QuerySubject!]` return type.

## Test plan

- [x] `TestCreateQuery_WithDatasetURNs` — verifies subjects sent as flat array with `datasetUrn` field
- [x] `TestUpdateQuery_WithDatasetURNs` — verifies same for update path
- [x] `TestCreateQuery` — verifies no-dataset case still works (empty subjects array)
- [x] All existing query tests pass
- [x] `make verify` passes (lint, vet, race, coverage, mutation, security)
- [ ] Manual: run `apply_knowledge` with `add_curated_query` change type against a live DataHub v1.3+ instance