### PR TITLE
feat: add Tool.Title, fix OpenWorldHint, add OutputSchema (#68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,34 +100,38 @@ export DATAHUB_TOKEN=your_token
 
 ## Available Tools (19 total: 12 read + 7 write)
 
+Each tool has a `Title` (human-readable display name shown in MCP clients like Claude Desktop),
+an `OutputSchema` (JSON Schema describing the response structure), and `Annotations`.
+All are customizable via the three-tier priority pattern.
+
 ### Read Tools
 
-| Tool | Description |
-|------|-------------|
-| `datahub_search` | Search entities by query and type |
-| `datahub_get_entity` | Get entity metadata by URN |
-| `datahub_get_schema` | Get dataset schema |
-| `datahub_get_lineage` | Get upstream/downstream lineage |
-| `datahub_get_column_lineage` | Get fine-grained column-level lineage |
-| `datahub_get_queries` | Get associated SQL queries |
-| `datahub_get_glossary_term` | Get glossary term details |
-| `datahub_list_tags` | List available tags |
-| `datahub_list_domains` | List data domains |
-| `datahub_list_data_products` | List data products |
-| `datahub_get_data_product` | Get data product details |
-| `datahub_list_connections` | List configured DataHub server connections |
+| Tool | Title | Description |
+|------|-------|-------------|
+| `datahub_search` | Search Catalog | Search entities by query and type |
+| `datahub_get_entity` | Get Entity | Get entity metadata by URN |
+| `datahub_get_schema` | Get Schema | Get dataset schema |
+| `datahub_get_lineage` | Get Lineage | Get upstream/downstream lineage |
+| `datahub_get_column_lineage` | Get Column Lineage | Get fine-grained column-level lineage |
+| `datahub_get_queries` | Get Queries | Get associated SQL queries |
+| `datahub_get_glossary_term` | Get Glossary Term | Get glossary term details |
+| `datahub_list_tags` | List Tags | List available tags |
+| `datahub_list_domains` | List Domains | List data domains |
+| `datahub_list_data_products` | List Data Products | List data products |
+| `datahub_get_data_product` | Get Data Product | Get data product details |
+| `datahub_list_connections` | List Connections | List configured DataHub server connections |
 
 ### Write Tools (require `WriteEnabled: true`)
 
-| Tool | Description |
-|------|-------------|
-| `datahub_update_description` | Update entity description |
-| `datahub_add_tag` | Add a tag to an entity |
-| `datahub_remove_tag` | Remove a tag from an entity |
-| `datahub_add_glossary_term` | Add a glossary term to an entity |
-| `datahub_remove_glossary_term` | Remove a glossary term from an entity |
-| `datahub_add_link` | Add a link to an entity |
-| `datahub_remove_link` | Remove a link from an entity |
+| Tool | Title | Description |
+|------|-------|-------------|
+| `datahub_update_description` | Update Description | Update entity description |
+| `datahub_add_tag` | Add Tag | Add a tag to an entity |
+| `datahub_remove_tag` | Remove Tag | Remove a tag from an entity |
+| `datahub_add_glossary_term` | Add Glossary Term | Add a glossary term to an entity |
+| `datahub_remove_glossary_term` | Remove Glossary Term | Remove a glossary term from an entity |
+| `datahub_add_link` | Add Link | Add a link to an entity |
+| `datahub_remove_link` | Remove Link | Remove a link from an entity |
 
 ## Description Overrides
 
@@ -139,6 +143,22 @@ Tool descriptions can be customized at three levels of priority:
 
 Descriptions can also be set via config file (`toolkit.descriptions` section) or the `Descriptions` field in `server.Options`.
 
+## Title Overrides
+
+Tool display names (shown in MCP clients) follow the same three-level priority:
+
+1. **Per-registration** (highest): `toolkit.RegisterWith(server, tools.ToolSearch, tools.WithTitle("My Search"))`
+2. **Toolkit-level**: `tools.NewToolkit(client, cfg, tools.WithTitles(map[tools.ToolName]string{...}))`
+3. **Default**: Built-in titles from `pkg/tools/titles.go`
+
+## OutputSchema Overrides
+
+Tool output schemas (JSON Schema describing the response) follow the same three-level priority:
+
+1. **Per-registration** (highest): `toolkit.RegisterWith(server, tools.ToolSearch, tools.WithOutputSchema(schema))`
+2. **Toolkit-level**: `tools.NewToolkit(client, cfg, tools.WithOutputSchemas(map[tools.ToolName]any{...}))`
+3. **Default**: Built-in schemas from `pkg/tools/output_schemas.go`
+
 ## Annotation Overrides
 
 MCP tool annotations (behavior hints per the MCP specification) follow the same three-level priority:
@@ -149,8 +169,10 @@ MCP tool annotations (behavior hints per the MCP specification) follow the same 
 
 Default annotations for all 19 tools:
 
-- **Read tools** (12): `ReadOnlyHint: true`, `IdempotentHint: true`, `OpenWorldHint: false`
-- **Write tools** (7): `DestructiveHint: false`, `IdempotentHint: true`, `OpenWorldHint: false`
+- **Read tools** (12): `ReadOnlyHint: true`, `IdempotentHint: true`, `OpenWorldHint: true`
+- **Write tools** (7): `DestructiveHint: false`, `IdempotentHint: true`, `OpenWorldHint: true`
+
+`OpenWorldHint: true` is correct because all tools communicate with an external DataHub instance.
 
 ## Extensions Package (`pkg/extensions/`)
 

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -205,8 +205,88 @@ func DefaultAnnotations(name ToolName) *mcp.ToolAnnotations
 
 | Tool Category | ReadOnlyHint | DestructiveHint | IdempotentHint | OpenWorldHint |
 |---------------|:------------:|:---------------:|:--------------:|:-------------:|
-| Read tools (12) | `true` | _(default)_ | `true` | `false` |
-| Write tools (7) | `false` | `false` | `true` | `false` |
+| Read tools (12) | `true` | _(default)_ | `true` | `true` |
+| Write tools (7) | `false` | `false` | `true` | `true` |
+
+`OpenWorldHint` is `true` for all tools because every tool communicates with an external DataHub instance.
+
+### WithTitles
+
+Overrides tool display names at the toolkit level. Titles appear in MCP clients (e.g., Claude Desktop) instead of raw tool names.
+
+```go
+func WithTitles(titles map[ToolName]string) ToolkitOption
+```
+
+**Example:**
+
+```go
+toolkit := tools.NewToolkit(datahubClient, config,
+    tools.WithTitles(map[tools.ToolName]string{
+        tools.ToolSearch: "Search Our Catalog",
+    }),
+)
+```
+
+### WithTitle
+
+Overrides the display title for a single tool at registration time.
+
+```go
+func WithTitle(title string) ToolOption
+```
+
+**Example:**
+
+```go
+toolkit.RegisterWith(server, tools.ToolSearch,
+    tools.WithTitle("Search Our Catalog"),
+)
+```
+
+**Title Priority:**
+
+1. Per-registration `WithTitle()` (highest)
+2. Toolkit-level `WithTitles()` map
+3. Built-in default title (lowest)
+
+### DefaultTitle
+
+Returns the default display title for a tool by name. Returns empty string for unknown tool names.
+
+```go
+func DefaultTitle(name ToolName) string
+```
+
+### WithOutputSchemas
+
+Overrides the output JSON Schema for multiple tools at the toolkit level.
+
+```go
+func WithOutputSchemas(schemas map[ToolName]any) ToolkitOption
+```
+
+### WithOutputSchema
+
+Overrides the output JSON Schema for a single tool at registration time.
+
+```go
+func WithOutputSchema(schema any) ToolOption
+```
+
+**OutputSchema Priority:**
+
+1. Per-registration `WithOutputSchema()` (highest)
+2. Toolkit-level `WithOutputSchemas()` map
+3. Built-in default output schema (lowest)
+
+### DefaultOutputSchema
+
+Returns the default output JSON Schema for a tool by name. Returns nil for unknown tool names.
+
+```go
+func DefaultOutputSchema(name ToolName) json.RawMessage
+```
 
 ## Tool Names
 

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -11,7 +11,9 @@ All tools include [MCP tool annotations](https://modelcontextprotocol.io/specifi
 | `ReadOnlyHint` | `true` | `false` | Whether the tool only reads data |
 | `DestructiveHint` | _(default)_ | `false` | Whether the tool may destructively update |
 | `IdempotentHint` | `true` | `true` | Whether repeated calls produce the same result |
-| `OpenWorldHint` | `false` | `false` | Whether the tool interacts with external entities |
+| `OpenWorldHint` | `true` | `true` | Whether the tool interacts with external entities |
+
+`OpenWorldHint` is `true` for all tools because every tool communicates with an external DataHub instance.
 
 These annotations help MCP clients make informed decisions about tool invocation (e.g., auto-approving read-only tools). Library users can override annotations per-tool or per-toolkit; see the [Tools API Reference](../reference/tools-api.md#withannotations).
 

--- a/pkg/tools/annotations.go
+++ b/pkg/tools/annotations.go
@@ -15,27 +15,27 @@ func boolPtr(b bool) *bool {
 //   - OpenWorldHint (*bool, default true): tool interacts with external entities
 var defaultAnnotations = map[ToolName]*mcp.ToolAnnotations{
 	// Read-only tools
-	ToolSearch:           {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetEntity:        {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetSchema:        {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetLineage:       {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetColumnLineage: {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetQueries:       {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetGlossaryTerm:  {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolListTags:         {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolListDomains:      {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolListDataProducts: {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolGetDataProduct:   {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolListConnections:  {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(false)},
+	ToolSearch:           {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetEntity:        {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetSchema:        {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetLineage:       {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetColumnLineage: {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetQueries:       {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetGlossaryTerm:  {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolListTags:         {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolListDomains:      {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolListDataProducts: {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolGetDataProduct:   {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolListConnections:  {ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: boolPtr(true)},
 
 	// Write tools
-	ToolUpdateDescription:  {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolAddTag:             {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolRemoveTag:          {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolAddGlossaryTerm:    {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolRemoveGlossaryTerm: {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolAddLink:            {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
-	ToolRemoveLink:         {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
+	ToolUpdateDescription:  {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolAddTag:             {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolRemoveTag:          {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolAddGlossaryTerm:    {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolRemoveGlossaryTerm: {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolAddLink:            {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
+	ToolRemoveLink:         {DestructiveHint: boolPtr(false), IdempotentHint: true, OpenWorldHint: boolPtr(true)},
 }
 
 // DefaultAnnotations returns the default annotations for a tool.

--- a/pkg/tools/annotations_test.go
+++ b/pkg/tools/annotations_test.go
@@ -71,8 +71,8 @@ func TestDefaultAnnotations_ReadOnlyTools(t *testing.T) {
 			if !ann.IdempotentHint {
 				t.Errorf("expected IdempotentHint=true for %s", name)
 			}
-			if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
-				t.Errorf("expected OpenWorldHint=false for %s", name)
+			if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+				t.Errorf("expected OpenWorldHint=true for %s", name)
 			}
 		})
 	}
@@ -97,8 +97,8 @@ func TestDefaultAnnotations_WriteTools(t *testing.T) {
 			if !ann.IdempotentHint {
 				t.Errorf("expected IdempotentHint=true for %s", name)
 			}
-			if ann.OpenWorldHint == nil || *ann.OpenWorldHint {
-				t.Errorf("expected OpenWorldHint=false for %s", name)
+			if ann.OpenWorldHint == nil || !*ann.OpenWorldHint {
+				t.Errorf("expected OpenWorldHint=true for %s", name)
 			}
 		})
 	}

--- a/pkg/tools/column_lineage.go
+++ b/pkg/tools/column_lineage.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerGetColumnLineageTool(server *mcp.Server, cfg *toolConf
 	wrappedHandler := t.wrapHandler(ToolGetColumnLineage, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetColumnLineage),
-		Description: t.getDescription(ToolGetColumnLineage, cfg),
-		Annotations: t.getAnnotations(ToolGetColumnLineage, cfg),
-		Icons:       t.getIcons(ToolGetColumnLineage, cfg),
+		Name:         string(ToolGetColumnLineage),
+		Description:  t.getDescription(ToolGetColumnLineage, cfg),
+		Annotations:  t.getAnnotations(ToolGetColumnLineage, cfg),
+		Icons:        t.getIcons(ToolGetColumnLineage, cfg),
+		Title:        t.getTitle(ToolGetColumnLineage, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetColumnLineage, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetColumnLineageInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/connections.go
+++ b/pkg/tools/connections.go
@@ -36,10 +36,12 @@ func (t *Toolkit) registerListConnectionsTool(server *mcp.Server, cfg *toolConfi
 
 	// Register with MCP
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolListConnections),
-		Description: t.getDescription(ToolListConnections, cfg),
-		Annotations: t.getAnnotations(ToolListConnections, cfg),
-		Icons:       t.getIcons(ToolListConnections, cfg),
+		Name:         string(ToolListConnections),
+		Description:  t.getDescription(ToolListConnections, cfg),
+		Annotations:  t.getAnnotations(ToolListConnections, cfg),
+		Icons:        t.getIcons(ToolListConnections, cfg),
+		Title:        t.getTitle(ToolListConnections, cfg),
+		OutputSchema: t.getOutputSchema(ToolListConnections, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListConnectionsInput) (*mcp.CallToolResult, *ListConnectionsOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*ListConnectionsOutput); ok {

--- a/pkg/tools/dataproducts.go
+++ b/pkg/tools/dataproducts.go
@@ -24,10 +24,12 @@ func (t *Toolkit) registerListDataProductsTool(server *mcp.Server, cfg *toolConf
 	wrappedHandler := t.wrapHandler(ToolListDataProducts, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolListDataProducts),
-		Description: t.getDescription(ToolListDataProducts, cfg),
-		Annotations: t.getAnnotations(ToolListDataProducts, cfg),
-		Icons:       t.getIcons(ToolListDataProducts, cfg),
+		Name:         string(ToolListDataProducts),
+		Description:  t.getDescription(ToolListDataProducts, cfg),
+		Annotations:  t.getAnnotations(ToolListDataProducts, cfg),
+		Icons:        t.getIcons(ToolListDataProducts, cfg),
+		Title:        t.getTitle(ToolListDataProducts, cfg),
+		OutputSchema: t.getOutputSchema(ToolListDataProducts, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListDataProductsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})
@@ -74,10 +76,12 @@ func (t *Toolkit) registerGetDataProductTool(server *mcp.Server, cfg *toolConfig
 	wrappedHandler := t.wrapHandler(ToolGetDataProduct, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetDataProduct),
-		Description: t.getDescription(ToolGetDataProduct, cfg),
-		Annotations: t.getAnnotations(ToolGetDataProduct, cfg),
-		Icons:       t.getIcons(ToolGetDataProduct, cfg),
+		Name:         string(ToolGetDataProduct),
+		Description:  t.getDescription(ToolGetDataProduct, cfg),
+		Annotations:  t.getAnnotations(ToolGetDataProduct, cfg),
+		Icons:        t.getIcons(ToolGetDataProduct, cfg),
+		Title:        t.getTitle(ToolGetDataProduct, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetDataProduct, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetDataProductInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/domains.go
+++ b/pkg/tools/domains.go
@@ -24,10 +24,12 @@ func (t *Toolkit) registerListDomainsTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolListDomains, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolListDomains),
-		Description: t.getDescription(ToolListDomains, cfg),
-		Annotations: t.getAnnotations(ToolListDomains, cfg),
-		Icons:       t.getIcons(ToolListDomains, cfg),
+		Name:         string(ToolListDomains),
+		Description:  t.getDescription(ToolListDomains, cfg),
+		Annotations:  t.getAnnotations(ToolListDomains, cfg),
+		Icons:        t.getIcons(ToolListDomains, cfg),
+		Title:        t.getTitle(ToolListDomains, cfg),
+		OutputSchema: t.getOutputSchema(ToolListDomains, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListDomainsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/entity.go
+++ b/pkg/tools/entity.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerGetEntityTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolGetEntity, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetEntity),
-		Description: t.getDescription(ToolGetEntity, cfg),
-		Annotations: t.getAnnotations(ToolGetEntity, cfg),
-		Icons:       t.getIcons(ToolGetEntity, cfg),
+		Name:         string(ToolGetEntity),
+		Description:  t.getDescription(ToolGetEntity, cfg),
+		Annotations:  t.getAnnotations(ToolGetEntity, cfg),
+		Icons:        t.getIcons(ToolGetEntity, cfg),
+		Title:        t.getTitle(ToolGetEntity, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetEntity, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetEntityInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/glossary.go
+++ b/pkg/tools/glossary.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerGetGlossaryTermTool(server *mcp.Server, cfg *toolConfi
 	wrappedHandler := t.wrapHandler(ToolGetGlossaryTerm, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetGlossaryTerm),
-		Description: t.getDescription(ToolGetGlossaryTerm, cfg),
-		Annotations: t.getAnnotations(ToolGetGlossaryTerm, cfg),
-		Icons:       t.getIcons(ToolGetGlossaryTerm, cfg),
+		Name:         string(ToolGetGlossaryTerm),
+		Description:  t.getDescription(ToolGetGlossaryTerm, cfg),
+		Annotations:  t.getAnnotations(ToolGetGlossaryTerm, cfg),
+		Icons:        t.getIcons(ToolGetGlossaryTerm, cfg),
+		Title:        t.getTitle(ToolGetGlossaryTerm, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetGlossaryTermInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/lineage.go
+++ b/pkg/tools/lineage.go
@@ -30,10 +30,12 @@ func (t *Toolkit) registerGetLineageTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolGetLineage, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetLineage),
-		Description: t.getDescription(ToolGetLineage, cfg),
-		Annotations: t.getAnnotations(ToolGetLineage, cfg),
-		Icons:       t.getIcons(ToolGetLineage, cfg),
+		Name:         string(ToolGetLineage),
+		Description:  t.getDescription(ToolGetLineage, cfg),
+		Annotations:  t.getAnnotations(ToolGetLineage, cfg),
+		Icons:        t.getIcons(ToolGetLineage, cfg),
+		Title:        t.getTitle(ToolGetLineage, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetLineage, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetLineageInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/options.go
+++ b/pkg/tools/options.go
@@ -38,10 +38,12 @@ func WithDescriptions(descs map[ToolName]string) ToolkitOption {
 
 // toolConfig holds per-registration configuration.
 type toolConfig struct {
-	middlewares []ToolMiddleware
-	description *string
-	annotations *mcp.ToolAnnotations
-	icons       []mcp.Icon
+	middlewares  []ToolMiddleware
+	description  *string
+	annotations  *mcp.ToolAnnotations
+	icons        []mcp.Icon
+	title        *string
+	outputSchema any
 }
 
 // ToolOption configures a single tool registration.
@@ -100,6 +102,46 @@ func WithIcons(icons map[ToolName][]mcp.Icon) ToolkitOption {
 func WithIcon(icons []mcp.Icon) ToolOption {
 	return func(cfg *toolConfig) {
 		cfg.icons = icons
+	}
+}
+
+// WithTitles sets toolkit-level title overrides for multiple tools.
+// These take priority over default titles but are overridden by
+// per-registration WithTitle options.
+func WithTitles(titles map[ToolName]string) ToolkitOption {
+	return func(t *Toolkit) {
+		for name, title := range titles {
+			t.titles[name] = title
+		}
+	}
+}
+
+// WithTitle overrides the display title for a single tool registration.
+// This is the highest priority override, taking precedence over both
+// toolkit-level WithTitles and default titles.
+func WithTitle(title string) ToolOption {
+	return func(cfg *toolConfig) {
+		cfg.title = &title
+	}
+}
+
+// WithOutputSchemas sets toolkit-level output schema overrides for multiple tools.
+// These take priority over default output schemas but are overridden by
+// per-registration WithOutputSchema options.
+func WithOutputSchemas(schemas map[ToolName]any) ToolkitOption {
+	return func(t *Toolkit) {
+		for name, schema := range schemas {
+			t.outputSchemas[name] = schema
+		}
+	}
+}
+
+// WithOutputSchema overrides the output schema for a single tool registration.
+// This is the highest priority override, taking precedence over both
+// toolkit-level WithOutputSchemas and default output schemas.
+func WithOutputSchema(schema any) ToolOption {
+	return func(cfg *toolConfig) {
+		cfg.outputSchema = schema
 	}
 }
 

--- a/pkg/tools/output_schemas.go
+++ b/pkg/tools/output_schemas.go
@@ -1,0 +1,372 @@
+package tools
+
+import "encoding/json"
+
+// defaultOutputSchemas holds the default JSON Schema output descriptors for each built-in tool.
+// These declare the structure of the JSON objects returned by each tool to MCP clients.
+// Schemas are top-level objects; not exhaustive — they describe the primary response shape.
+var defaultOutputSchemas = map[ToolName]json.RawMessage{
+	ToolSearch:           schemaSearch,
+	ToolGetEntity:        schemaGetEntity,
+	ToolGetSchema:        schemaGetSchema,
+	ToolGetLineage:       schemaGetLineage,
+	ToolGetColumnLineage: schemaGetColumnLineage,
+	ToolGetQueries:       schemaGetQueries,
+	ToolGetGlossaryTerm:  schemaGetGlossaryTerm,
+	ToolListTags:         schemaListTags,
+	ToolListDomains:      schemaListDomains,
+	ToolListDataProducts: schemaListDataProducts,
+	ToolGetDataProduct:   schemaGetDataProduct,
+	ToolListConnections:  schemaListConnections,
+	// Write tools
+	ToolUpdateDescription:  schemaUpdateDescription,
+	ToolAddTag:             schemaAddTag,
+	ToolRemoveTag:          schemaRemoveTag,
+	ToolAddGlossaryTerm:    schemaAddGlossaryTerm,
+	ToolRemoveGlossaryTerm: schemaRemoveGlossaryTerm,
+	ToolAddLink:            schemaAddLink,
+	ToolRemoveLink:         schemaRemoveLink,
+}
+
+// DefaultOutputSchema returns the default output JSON Schema for a tool.
+// Returns nil if the tool name is not recognized.
+func DefaultOutputSchema(name ToolName) json.RawMessage {
+	return defaultOutputSchemas[name]
+}
+
+// getOutputSchema resolves the output schema for a tool using the priority chain:
+//  1. Per-registration cfg.outputSchema (highest)
+//  2. Toolkit-level t.outputSchemas map
+//  3. defaultOutputSchemas map (lowest/default)
+func (t *Toolkit) getOutputSchema(name ToolName, cfg *toolConfig) any {
+	// Highest priority: per-registration override
+	if cfg != nil && cfg.outputSchema != nil {
+		return cfg.outputSchema
+	}
+
+	// Middle priority: toolkit-level override
+	if schema, ok := t.outputSchemas[name]; ok {
+		return schema
+	}
+
+	// Lowest priority: default
+	return defaultOutputSchemas[name]
+}
+
+// Individual output schema definitions for each tool.
+// Keeping them as package-level variables avoids an oversized init() function.
+
+var schemaSearch = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "total":    {"type": "integer", "description": "Total number of matching entities"},
+    "entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":         {"type": "string"},
+          "name":        {"type": "string"},
+          "type":        {"type": "string"},
+          "description": {"type": "string"},
+          "platform":    {"type": "string"}
+        }
+      }
+    },
+    "query_context": {
+      "type": "object",
+      "description": "Optional: query engine availability per entity URN",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "available": {"type": "boolean"},
+          "table":     {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaGetEntity = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":         {"type": "string"},
+    "name":        {"type": "string"},
+    "type":        {"type": "string"},
+    "description": {"type": "string"},
+    "owners":      {"type": "array", "items": {"type": "string"}},
+    "tags":        {"type": "array", "items": {"type": "string"}},
+    "domain":      {"type": "string"},
+    "deprecated":  {"type": "boolean"},
+    "query_table": {"type": "string", "description": "Optional: resolved query engine table path"}
+  }
+}`)
+
+var schemaGetSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":   {"type": "string"},
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "fieldPath":   {"type": "string"},
+          "type":        {"type": "string"},
+          "description": {"type": "string"},
+          "nullable":    {"type": "boolean"}
+        }
+      }
+    },
+    "query_table": {"type": "string", "description": "Optional: resolved query engine table path"}
+  }
+}`)
+
+var schemaGetLineage = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":       {"type": "string"},
+    "direction": {"type": "string", "enum": ["upstream", "downstream"]},
+    "entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":  {"type": "string"},
+          "name": {"type": "string"},
+          "type": {"type": "string"}
+        }
+      }
+    },
+    "execution_context": {
+      "type": "object",
+      "description": "Optional: query engine context per entity URN",
+      "additionalProperties": {"type": "object"}
+    }
+  }
+}`)
+
+var schemaGetColumnLineage = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn": {"type": "string"},
+    "columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "downstreamColumn": {"type": "string"},
+          "upstreamColumns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "datasetUrn": {"type": "string"},
+                "column":     {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+var schemaGetQueries = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn": {"type": "string"},
+    "queries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name":        {"type": "string"},
+          "description": {"type": "string"},
+          "statement":   {"type": "string"},
+          "language":    {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaGetGlossaryTerm = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":        {"type": "string"},
+    "name":       {"type": "string"},
+    "definition": {"type": "string"},
+    "entities": {
+      "type": "array",
+      "description": "Datasets and columns linked to this term",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":    {"type": "string"},
+          "column": {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaListTags = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":         {"type": "string"},
+          "name":        {"type": "string"},
+          "description": {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaListDomains = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "domains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":         {"type": "string"},
+          "name":        {"type": "string"},
+          "description": {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaListDataProducts = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "data_products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":         {"type": "string"},
+          "name":        {"type": "string"},
+          "description": {"type": "string"},
+          "domain":      {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaGetDataProduct = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":         {"type": "string"},
+    "name":        {"type": "string"},
+    "description": {"type": "string"},
+    "domain":      {"type": "string"},
+    "owners":      {"type": "array", "items": {"type": "string"}},
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "urn":  {"type": "string"},
+          "name": {"type": "string"},
+          "type": {"type": "string"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaListConnections = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "connections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name":       {"type": "string"},
+          "url":        {"type": "string"},
+          "is_default": {"type": "boolean"}
+        }
+      }
+    }
+  }
+}`)
+
+var schemaUpdateDescription = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":         {"type": "string"},
+    "description": {"type": "string"},
+    "aspect":      {"type": "string"},
+    "action":      {"type": "string"}
+  }
+}`)
+
+var schemaAddTag = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":    {"type": "string"},
+    "tag":    {"type": "string"},
+    "aspect": {"type": "string"},
+    "action": {"type": "string"}
+  }
+}`)
+
+var schemaRemoveTag = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":    {"type": "string"},
+    "tag":    {"type": "string"},
+    "aspect": {"type": "string"},
+    "action": {"type": "string"}
+  }
+}`)
+
+var schemaAddGlossaryTerm = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":           {"type": "string"},
+    "glossary_term": {"type": "string"},
+    "aspect":        {"type": "string"},
+    "action":        {"type": "string"}
+  }
+}`)
+
+var schemaRemoveGlossaryTerm = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":           {"type": "string"},
+    "glossary_term": {"type": "string"},
+    "aspect":        {"type": "string"},
+    "action":        {"type": "string"}
+  }
+}`)
+
+var schemaAddLink = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":    {"type": "string"},
+    "url":    {"type": "string"},
+    "label":  {"type": "string"},
+    "action": {"type": "string"}
+  }
+}`)
+
+var schemaRemoveLink = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "urn":    {"type": "string"},
+    "url":    {"type": "string"},
+    "action": {"type": "string"}
+  }
+}`)

--- a/pkg/tools/output_schemas_test.go
+++ b/pkg/tools/output_schemas_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultOutputSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName ToolName
+		wantNil  bool
+	}{
+		{name: "known tool returns schema", toolName: ToolSearch, wantNil: false},
+		{name: "unknown tool returns nil", toolName: ToolName("nonexistent_tool"), wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultOutputSchema(tt.toolName)
+			if tt.wantNil && got != nil {
+				t.Errorf("DefaultOutputSchema(%q) = %v, want nil", tt.toolName, got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Errorf("DefaultOutputSchema(%q) returned nil, want non-nil", tt.toolName)
+			}
+		})
+	}
+}
+
+func TestDefaultOutputSchema_AllToolsCovered(t *testing.T) {
+	allTools := append(AllTools(), WriteTools()...)
+	for _, name := range allTools {
+		schema := DefaultOutputSchema(name)
+		if schema == nil {
+			t.Errorf("no default output schema for tool %q", name)
+		}
+	}
+}
+
+func TestDefaultOutputSchema_ValidJSON(t *testing.T) {
+	allTools := append(AllTools(), WriteTools()...)
+	for _, name := range allTools {
+		schema := DefaultOutputSchema(name)
+		if schema == nil {
+			continue
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(schema, &parsed); err != nil {
+			t.Errorf("tool %q has invalid JSON schema: %v", name, err)
+		}
+		if schemaType, ok := parsed["type"]; !ok || schemaType != "object" {
+			t.Errorf("tool %q schema missing top-level type=object", name)
+		}
+	}
+}
+
+func TestGetOutputSchema_Priority(t *testing.T) {
+	customSchema := json.RawMessage(`{"type":"object","properties":{"custom":{"type":"string"}}}`)
+
+	tk := &Toolkit{
+		outputSchemas:   map[ToolName]any{ToolSearch: customSchema},
+		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		registeredTools: make(map[ToolName]bool),
+	}
+
+	tests := []struct {
+		name     string
+		cfg      *toolConfig
+		wantType string // "per-reg", "toolkit", "default"
+	}{
+		{
+			name:     "per-registration override takes highest priority",
+			cfg:      &toolConfig{outputSchema: json.RawMessage(`{"type":"object"}`)},
+			wantType: "per-reg",
+		},
+		{
+			name:     "toolkit-level override takes middle priority",
+			cfg:      nil,
+			wantType: "toolkit",
+		},
+		{
+			name:     "empty cfg falls through to toolkit override",
+			cfg:      &toolConfig{},
+			wantType: "toolkit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tk.getOutputSchema(ToolSearch, tt.cfg)
+			if got == nil {
+				t.Fatal("getOutputSchema() returned nil")
+			}
+
+			// Verify it's the right schema by checking it's not nil and valid
+			switch tt.wantType {
+			case "per-reg":
+				perReg, ok := tt.cfg.outputSchema.(json.RawMessage)
+				if !ok {
+					t.Fatal("per-reg schema is not json.RawMessage")
+				}
+				gotBytes, ok2 := got.(json.RawMessage)
+				if !ok2 {
+					t.Fatal("result is not json.RawMessage")
+				}
+				if string(gotBytes) != string(perReg) {
+					t.Errorf("getOutputSchema() = %s, want per-reg %s", gotBytes, perReg)
+				}
+			case "toolkit":
+				gotBytes, ok := got.(json.RawMessage)
+				if !ok {
+					t.Fatal("result is not json.RawMessage")
+				}
+				if string(gotBytes) != string(customSchema) {
+					t.Errorf("getOutputSchema() = %s, want toolkit schema", gotBytes)
+				}
+			}
+		})
+	}
+}
+
+func TestGetOutputSchema_DefaultFallback(t *testing.T) {
+	tk := &Toolkit{
+		outputSchemas:   make(map[ToolName]any),
+		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		registeredTools: make(map[ToolName]bool),
+	}
+
+	got := tk.getOutputSchema(ToolSearch, nil)
+	if got == nil {
+		t.Fatal("getOutputSchema() with no overrides returned nil")
+	}
+
+	want := defaultOutputSchemas[ToolSearch]
+	gotBytes, ok := got.(json.RawMessage)
+	if !ok {
+		t.Fatal("result is not json.RawMessage")
+	}
+	if string(gotBytes) != string(want) {
+		t.Errorf("getOutputSchema() default = %s, want %s", gotBytes, want)
+	}
+}

--- a/pkg/tools/queries.go
+++ b/pkg/tools/queries.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerGetQueriesTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolGetQueries, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetQueries),
-		Description: t.getDescription(ToolGetQueries, cfg),
-		Annotations: t.getAnnotations(ToolGetQueries, cfg),
-		Icons:       t.getIcons(ToolGetQueries, cfg),
+		Name:         string(ToolGetQueries),
+		Description:  t.getDescription(ToolGetQueries, cfg),
+		Annotations:  t.getAnnotations(ToolGetQueries, cfg),
+		Icons:        t.getIcons(ToolGetQueries, cfg),
+		Title:        t.getTitle(ToolGetQueries, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetQueries, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetQueriesInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerGetSchemaTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolGetSchema, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolGetSchema),
-		Description: t.getDescription(ToolGetSchema, cfg),
-		Annotations: t.getAnnotations(ToolGetSchema, cfg),
-		Icons:       t.getIcons(ToolGetSchema, cfg),
+		Name:         string(ToolGetSchema),
+		Description:  t.getDescription(ToolGetSchema, cfg),
+		Annotations:  t.getAnnotations(ToolGetSchema, cfg),
+		Icons:        t.getIcons(ToolGetSchema, cfg),
+		Title:        t.getTitle(ToolGetSchema, cfg),
+		OutputSchema: t.getOutputSchema(ToolGetSchema, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetSchemaInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -32,10 +32,12 @@ func (t *Toolkit) registerSearchTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolSearch, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolSearch),
-		Description: t.getDescription(ToolSearch, cfg),
-		Annotations: t.getAnnotations(ToolSearch, cfg),
-		Icons:       t.getIcons(ToolSearch, cfg),
+		Name:         string(ToolSearch),
+		Description:  t.getDescription(ToolSearch, cfg),
+		Annotations:  t.getAnnotations(ToolSearch, cfg),
+		Icons:        t.getIcons(ToolSearch, cfg),
+		Title:        t.getTitle(ToolSearch, cfg),
+		OutputSchema: t.getOutputSchema(ToolSearch, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/tags.go
+++ b/pkg/tools/tags.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerListTagsTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolListTags, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolListTags),
-		Description: t.getDescription(ToolListTags, cfg),
-		Annotations: t.getAnnotations(ToolListTags, cfg),
-		Icons:       t.getIcons(ToolListTags, cfg),
+		Name:         string(ToolListTags),
+		Description:  t.getDescription(ToolListTags, cfg),
+		Annotations:  t.getAnnotations(ToolListTags, cfg),
+		Icons:        t.getIcons(ToolListTags, cfg),
+		Title:        t.getTitle(ToolListTags, cfg),
+		OutputSchema: t.getOutputSchema(ToolListTags, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ListTagsInput) (*mcp.CallToolResult, any, error) {
 		return wrappedHandler(ctx, req, input)
 	})

--- a/pkg/tools/titles.go
+++ b/pkg/tools/titles.go
@@ -1,0 +1,54 @@
+package tools
+
+// defaultTitles maps each tool to its default human-readable display name.
+// These are used by MCP clients (e.g., Claude Desktop) to display tools in the UI.
+// Display name precedence in the SDK: Tool.Title > ToolAnnotations.Title > Tool.Name.
+var defaultTitles = map[ToolName]string{
+	// Read tools
+	ToolSearch:           "Search Catalog",
+	ToolGetEntity:        "Get Entity",
+	ToolGetSchema:        "Get Schema",
+	ToolGetLineage:       "Get Lineage",
+	ToolGetColumnLineage: "Get Column Lineage",
+	ToolGetQueries:       "Get Queries",
+	ToolGetGlossaryTerm:  "Get Glossary Term",
+	ToolListTags:         "List Tags",
+	ToolListDomains:      "List Domains",
+	ToolListDataProducts: "List Data Products",
+	ToolGetDataProduct:   "Get Data Product",
+	ToolListConnections:  "List Connections",
+
+	// Write tools
+	ToolUpdateDescription:  "Update Description",
+	ToolAddTag:             "Add Tag",
+	ToolRemoveTag:          "Remove Tag",
+	ToolAddGlossaryTerm:    "Add Glossary Term",
+	ToolRemoveGlossaryTerm: "Remove Glossary Term",
+	ToolAddLink:            "Add Link",
+	ToolRemoveLink:         "Remove Link",
+}
+
+// DefaultTitle returns the default human-readable title for a tool.
+// Returns an empty string if the tool name is not recognized.
+func DefaultTitle(name ToolName) string {
+	return defaultTitles[name]
+}
+
+// getTitle resolves the title for a tool using the priority chain:
+//  1. Per-registration cfg.title (highest)
+//  2. Toolkit-level t.titles map
+//  3. defaultTitles map (lowest/default)
+func (t *Toolkit) getTitle(name ToolName, cfg *toolConfig) string {
+	// Highest priority: per-registration override
+	if cfg != nil && cfg.title != nil {
+		return *cfg.title
+	}
+
+	// Middle priority: toolkit-level override
+	if title, ok := t.titles[name]; ok {
+		return title
+	}
+
+	// Lowest priority: default
+	return defaultTitles[name]
+}

--- a/pkg/tools/titles_test.go
+++ b/pkg/tools/titles_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import "testing"
+
+func TestDefaultTitle(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  ToolName
+		wantEmpty bool
+	}{
+		{name: "known tool returns title", toolName: ToolSearch, wantEmpty: false},
+		{name: "unknown tool returns empty", toolName: ToolName("nonexistent_tool"), wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultTitle(tt.toolName)
+			if tt.wantEmpty && got != "" {
+				t.Errorf("DefaultTitle(%q) = %q, want empty string", tt.toolName, got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Errorf("DefaultTitle(%q) returned empty string, want non-empty", tt.toolName)
+			}
+		})
+	}
+}
+
+func TestDefaultTitle_AllToolsCovered(t *testing.T) {
+	allTools := append(AllTools(), WriteTools()...)
+	for _, name := range allTools {
+		title := DefaultTitle(name)
+		if title == "" {
+			t.Errorf("no default title for tool %q", name)
+		}
+	}
+}
+
+func TestGetTitle_Priority(t *testing.T) {
+	toolkitTitle := "toolkit-level title"
+	perRegTitle := "per-registration title"
+
+	tk := &Toolkit{
+		titles:          map[ToolName]string{ToolSearch: toolkitTitle},
+		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		registeredTools: make(map[ToolName]bool),
+	}
+
+	tests := []struct {
+		name string
+		cfg  *toolConfig
+		want string
+	}{
+		{
+			name: "per-registration override takes highest priority",
+			cfg:  &toolConfig{title: strPtr(perRegTitle)},
+			want: perRegTitle,
+		},
+		{
+			name: "toolkit-level override takes middle priority",
+			cfg:  nil,
+			want: toolkitTitle,
+		},
+		{
+			name: "toolkit-level with nil title in cfg",
+			cfg:  &toolConfig{},
+			want: toolkitTitle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tk.getTitle(ToolSearch, tt.cfg)
+			if got != tt.want {
+				t.Errorf("getTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTitle_DefaultFallback(t *testing.T) {
+	tk := &Toolkit{
+		titles:          make(map[ToolName]string),
+		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		registeredTools: make(map[ToolName]bool),
+	}
+
+	got := tk.getTitle(ToolSearch, nil)
+	want := defaultTitles[ToolSearch]
+	if got != want {
+		t.Errorf("getTitle() with no overrides = %q, want %q", got, want)
+	}
+}
+
+func TestGetTitle_NilConfig(t *testing.T) {
+	tk := &Toolkit{
+		titles:          make(map[ToolName]string),
+		toolMiddlewares: make(map[ToolName][]ToolMiddleware),
+		registeredTools: make(map[ToolName]bool),
+	}
+
+	got := tk.getTitle(ToolGetEntity, &toolConfig{})
+	want := defaultTitles[ToolGetEntity]
+	if got != want {
+		t.Errorf("getTitle() with empty cfg = %q, want %q", got, want)
+	}
+}

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -46,6 +46,12 @@ type Toolkit struct {
 	// Icon overrides (toolkit-level, set via WithIcons)
 	icons map[ToolName][]mcp.Icon
 
+	// Title overrides (toolkit-level, set via WithTitles)
+	titles map[ToolName]string
+
+	// OutputSchema overrides (toolkit-level, set via WithOutputSchemas)
+	outputSchemas map[ToolName]any
+
 	// Internal tracking
 	registeredTools map[ToolName]bool
 }
@@ -88,6 +94,8 @@ func newBaseToolkit(cfg Config) *Toolkit {
 		descriptions:    make(map[ToolName]string),
 		annotations:     make(map[ToolName]*mcp.ToolAnnotations),
 		icons:           make(map[ToolName][]mcp.Icon),
+		titles:          make(map[ToolName]string),
+		outputSchemas:   make(map[ToolName]any),
 		registeredTools: make(map[ToolName]bool),
 	}
 }

--- a/pkg/tools/write_description.go
+++ b/pkg/tools/write_description.go
@@ -25,10 +25,12 @@ func (t *Toolkit) registerUpdateDescriptionTool(server *mcp.Server, cfg *toolCon
 	wrappedHandler := t.wrapHandler(ToolUpdateDescription, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolUpdateDescription),
-		Description: t.getDescription(ToolUpdateDescription, cfg),
-		Annotations: t.getAnnotations(ToolUpdateDescription, cfg),
-		Icons:       t.getIcons(ToolUpdateDescription, cfg),
+		Name:         string(ToolUpdateDescription),
+		Description:  t.getDescription(ToolUpdateDescription, cfg),
+		Annotations:  t.getAnnotations(ToolUpdateDescription, cfg),
+		Icons:        t.getIcons(ToolUpdateDescription, cfg),
+		Title:        t.getTitle(ToolUpdateDescription, cfg),
+		OutputSchema: t.getOutputSchema(ToolUpdateDescription, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		input UpdateDescriptionInput,
 	) (*mcp.CallToolResult, *UpdateDescriptionOutput, error) {

--- a/pkg/tools/write_glossary_terms.go
+++ b/pkg/tools/write_glossary_terms.go
@@ -32,10 +32,12 @@ func (t *Toolkit) registerAddGlossaryTermTool(server *mcp.Server, cfg *toolConfi
 	wrappedHandler := t.wrapHandler(ToolAddGlossaryTerm, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolAddGlossaryTerm),
-		Description: t.getDescription(ToolAddGlossaryTerm, cfg),
-		Annotations: t.getAnnotations(ToolAddGlossaryTerm, cfg),
-		Icons:       t.getIcons(ToolAddGlossaryTerm, cfg),
+		Name:         string(ToolAddGlossaryTerm),
+		Description:  t.getDescription(ToolAddGlossaryTerm, cfg),
+		Annotations:  t.getAnnotations(ToolAddGlossaryTerm, cfg),
+		Icons:        t.getIcons(ToolAddGlossaryTerm, cfg),
+		Title:        t.getTitle(ToolAddGlossaryTerm, cfg),
+		OutputSchema: t.getOutputSchema(ToolAddGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddGlossaryTermInput) (*mcp.CallToolResult, *AddGlossaryTermOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddGlossaryTermOutput); ok {
@@ -57,10 +59,12 @@ func (t *Toolkit) registerRemoveGlossaryTermTool(server *mcp.Server, cfg *toolCo
 	wrappedHandler := t.wrapHandler(ToolRemoveGlossaryTerm, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolRemoveGlossaryTerm),
-		Description: t.getDescription(ToolRemoveGlossaryTerm, cfg),
-		Annotations: t.getAnnotations(ToolRemoveGlossaryTerm, cfg),
-		Icons:       t.getIcons(ToolRemoveGlossaryTerm, cfg),
+		Name:         string(ToolRemoveGlossaryTerm),
+		Description:  t.getDescription(ToolRemoveGlossaryTerm, cfg),
+		Annotations:  t.getAnnotations(ToolRemoveGlossaryTerm, cfg),
+		Icons:        t.getIcons(ToolRemoveGlossaryTerm, cfg),
+		Title:        t.getTitle(ToolRemoveGlossaryTerm, cfg),
+		OutputSchema: t.getOutputSchema(ToolRemoveGlossaryTerm, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		input RemoveGlossaryTermInput,
 	) (*mcp.CallToolResult, *RemoveGlossaryTermOutput, error) {

--- a/pkg/tools/write_links.go
+++ b/pkg/tools/write_links.go
@@ -33,10 +33,12 @@ func (t *Toolkit) registerAddLinkTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolAddLink, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolAddLink),
-		Description: t.getDescription(ToolAddLink, cfg),
-		Annotations: t.getAnnotations(ToolAddLink, cfg),
-		Icons:       t.getIcons(ToolAddLink, cfg),
+		Name:         string(ToolAddLink),
+		Description:  t.getDescription(ToolAddLink, cfg),
+		Annotations:  t.getAnnotations(ToolAddLink, cfg),
+		Icons:        t.getIcons(ToolAddLink, cfg),
+		Title:        t.getTitle(ToolAddLink, cfg),
+		OutputSchema: t.getOutputSchema(ToolAddLink, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddLinkInput) (*mcp.CallToolResult, *AddLinkOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddLinkOutput); ok {
@@ -58,10 +60,12 @@ func (t *Toolkit) registerRemoveLinkTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolRemoveLink, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolRemoveLink),
-		Description: t.getDescription(ToolRemoveLink, cfg),
-		Annotations: t.getAnnotations(ToolRemoveLink, cfg),
-		Icons:       t.getIcons(ToolRemoveLink, cfg),
+		Name:         string(ToolRemoveLink),
+		Description:  t.getDescription(ToolRemoveLink, cfg),
+		Annotations:  t.getAnnotations(ToolRemoveLink, cfg),
+		Icons:        t.getIcons(ToolRemoveLink, cfg),
+		Title:        t.getTitle(ToolRemoveLink, cfg),
+		OutputSchema: t.getOutputSchema(ToolRemoveLink, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input RemoveLinkInput) (*mcp.CallToolResult, *RemoveLinkOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*RemoveLinkOutput); ok {

--- a/pkg/tools/write_tags.go
+++ b/pkg/tools/write_tags.go
@@ -32,10 +32,12 @@ func (t *Toolkit) registerAddTagTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolAddTag, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolAddTag),
-		Description: t.getDescription(ToolAddTag, cfg),
-		Annotations: t.getAnnotations(ToolAddTag, cfg),
-		Icons:       t.getIcons(ToolAddTag, cfg),
+		Name:         string(ToolAddTag),
+		Description:  t.getDescription(ToolAddTag, cfg),
+		Annotations:  t.getAnnotations(ToolAddTag, cfg),
+		Icons:        t.getIcons(ToolAddTag, cfg),
+		Title:        t.getTitle(ToolAddTag, cfg),
+		OutputSchema: t.getOutputSchema(ToolAddTag, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input AddTagInput) (*mcp.CallToolResult, *AddTagOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*AddTagOutput); ok {
@@ -57,10 +59,12 @@ func (t *Toolkit) registerRemoveTagTool(server *mcp.Server, cfg *toolConfig) {
 	wrappedHandler := t.wrapHandler(ToolRemoveTag, baseHandler, cfg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        string(ToolRemoveTag),
-		Description: t.getDescription(ToolRemoveTag, cfg),
-		Annotations: t.getAnnotations(ToolRemoveTag, cfg),
-		Icons:       t.getIcons(ToolRemoveTag, cfg),
+		Name:         string(ToolRemoveTag),
+		Description:  t.getDescription(ToolRemoveTag, cfg),
+		Annotations:  t.getAnnotations(ToolRemoveTag, cfg),
+		Icons:        t.getIcons(ToolRemoveTag, cfg),
+		Title:        t.getTitle(ToolRemoveTag, cfg),
+		OutputSchema: t.getOutputSchema(ToolRemoveTag, cfg),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input RemoveTagInput) (*mcp.CallToolResult, *RemoveTagOutput, error) {
 		result, out, err := wrappedHandler(ctx, req, input)
 		if typed, ok := out.(*RemoveTagOutput); ok {


### PR DESCRIPTION
## Summary

Closes #68. Three enhancements that improve how DataHub MCP tools display in clients (e.g. Claude Desktop) and how they conform to the MCP specification.

---

## Changes

### 1. `Tool.Title` — Human-readable display names

All 19 tools now carry a `Title` field (e.g. `"Search Catalog"`, `"Get Lineage"`, `"Add Tag"`). MCP clients use this as the display name instead of the raw snake_case tool name.

**Display name precedence per MCP SDK:** `Tool.Title` > `ToolAnnotations.Title` > `Tool.Name`

New files:
- `pkg/tools/titles.go` — `defaultTitles` map, `DefaultTitle()` helper, `getTitle()` resolver
- `pkg/tools/titles_test.go` — table-driven tests including `AllToolsCovered` and priority chain

| Tool | Title |
|------|-------|
| `datahub_search` | Search Catalog |
| `datahub_get_entity` | Get Entity |
| `datahub_get_schema` | Get Schema |
| `datahub_get_lineage` | Get Lineage |
| `datahub_get_column_lineage` | Get Column Lineage |
| `datahub_get_queries` | Get Queries |
| `datahub_get_glossary_term` | Get Glossary Term |
| `datahub_list_tags` | List Tags |
| `datahub_list_domains` | List Domains |
| `datahub_list_data_products` | List Data Products |
| `datahub_get_data_product` | Get Data Product |
| `datahub_list_connections` | List Connections |
| `datahub_update_description` | Update Description |
| `datahub_add_tag` | Add Tag |
| `datahub_remove_tag` | Remove Tag |
| `datahub_add_glossary_term` | Add Glossary Term |
| `datahub_remove_glossary_term` | Remove Glossary Term |
| `datahub_add_link` | Add Link |
| `datahub_remove_link` | Remove Link |

---

### 2. `OpenWorldHint` — Corrected from `false` → `true`

Every tool in this library communicates with an external DataHub instance over the network. The previous `OpenWorldHint: false` was incorrect per the MCP spec definition:

> `OpenWorldHint: true` — the tool may interact with external entities not known at invocation time.

Changed in `pkg/tools/annotations.go` for all 19 tools. Tests updated accordingly.

---

### 3. `OutputSchema` — Declared response structure for all 19 tools

Each tool now carries a JSON Schema object describing the top-level structure of its response. This enables MCP clients to validate output shapes and render results more intelligently.

New files:
- `pkg/tools/output_schemas.go` — 19 per-tool `json.RawMessage` schema vars, `DefaultOutputSchema()` helper, `getOutputSchema()` resolver. Schemas are package-level `var` declarations (avoiding an oversized `init()` that would fail the `funlen` linter).
- `pkg/tools/output_schemas_test.go` — coverage for `DefaultOutputSchema`, valid JSON assertion on all schemas, and `getOutputSchema` priority chain.

---

### Three-tier priority pattern (consistent with existing API)

All three new properties follow the same override chain already used for descriptions, annotations, and icons:

```go
// Per-registration (highest priority)
toolkit.RegisterWith(server, tools.ToolSearch,
    tools.WithTitle("Search Our Catalog"),
    tools.WithOutputSchema(customSchema),
)

// Toolkit-level (middle priority)
toolkit := tools.NewToolkit(client, cfg,
    tools.WithTitles(map[tools.ToolName]string{
        tools.ToolSearch: "Search Our Catalog",
    }),
    tools.WithOutputSchemas(map[tools.ToolName]any{
        tools.ToolSearch: customSchema,
    }),
)

// Default (lowest priority) — built-in titles.go / output_schemas.go
```

New option functions added to `pkg/tools/options.go`:
- `WithTitle(string) ToolOption`
- `WithTitles(map[ToolName]string) ToolkitOption`
- `WithOutputSchema(any) ToolOption`
- `WithOutputSchemas(map[ToolName]any) ToolkitOption`

New fields added to `toolConfig`:
- `title *string`
- `outputSchema any`

New maps added to `Toolkit` struct (initialized in `newBaseToolkit`):
- `titles map[ToolName]string`
- `outputSchemas map[ToolName]any`

---

## Documentation

- `CLAUDE.md` — Updated Available Tools table with Title column; added Title Overrides and OutputSchema Overrides sections; corrected `OpenWorldHint` default to `true`
- `docs/server/tools.md` — Corrected annotations table (`OpenWorldHint: false` → `true`)
- `docs/reference/tools-api.md` — Corrected annotations defaults table; added `WithTitle`, `WithTitles`, `WithOutputSchema`, `WithOutputSchemas`, `DefaultTitle`, `DefaultOutputSchema` API entries

---

## Test plan

- [x] `make verify` — all checks pass (`golangci-lint`, `go vet`, `go test -race -shuffle=on`, coverage, security, deadcode, build-check)
- [x] `TestDefaultTitle_AllToolsCovered` — all 19 tools have a non-empty default title
- [x] `TestGetTitle_Priority` — per-registration > toolkit > default
- [x] `TestDefaultAnnotations_ReadOnlyTools` — `OpenWorldHint == true` for all 12 read tools
- [x] `TestDefaultAnnotations_WriteTools` — `OpenWorldHint == true` for all 7 write tools
- [x] `TestDefaultOutputSchema_AllToolsCovered` — all 19 tools have a non-nil default output schema
- [x] `TestDefaultOutputSchema_ValidJSON` — all 19 schemas parse as valid JSON with `type: object`
- [x] `TestGetOutputSchema_Priority` — per-registration > toolkit > default
- [x] `TestWithTitle`, `TestWithTitles`, `TestWithTitles_Merge` — new option functions
- [x] `TestWithOutputSchema`, `TestWithOutputSchemas` — new option functions