### PR TITLE
fix: resolve four DataHub 1.4.x write method bugs

### DIFF
--- a/pkg/client/incidents.go
+++ b/pkg/client/incidents.go
@@ -68,7 +68,7 @@ mutation raiseIncident($input: RaiseIncidentInput!) {
 
 	// UpdateIncidentStatusMutation resolves or reactivates an incident.
 	UpdateIncidentStatusMutation = `
-mutation updateIncidentStatus($urn: String!, $input: UpdateIncidentStatusInput!) {
+mutation updateIncidentStatus($urn: String!, $input: IncidentStatusInput!) {
   updateIncidentStatus(urn: $urn, input: $input)
 }
 `

--- a/pkg/client/structured_properties.go
+++ b/pkg/client/structured_properties.go
@@ -233,8 +233,8 @@ func (c *Client) UpsertStructuredProperties(ctx context.Context, urn string, pro
 	propInputs := make([]map[string]any, 0, len(properties))
 	for _, p := range properties {
 		propInputs = append(propInputs, map[string]any{
-			"propertyUrn": p.PropertyURN,
-			"values":      p.Values,
+			"structuredPropertyUrn": p.PropertyURN,
+			"values":                p.Values,
 		})
 	}
 

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -137,14 +137,32 @@ func (a *descriptionAspect) setDescription(fieldName, value string) error {
 	return nil
 }
 
-// UpdateDescription sets the editable description for any entity using read-modify-write.
-// Resolves the correct aspect name and field name based on the entity type in the URN.
+// UpdateDescription sets the editable description for any entity.
+// Uses GraphQL for domain, glossaryTerm, and glossaryNode entities because the REST
+// API does not support their description aspects. Uses REST read-modify-write for all
+// other entity types.
 func (c *Client) UpdateDescription(ctx context.Context, urn, description string) error {
 	entityType, err := entityTypeFromURN(urn)
 	if err != nil {
 		return fmt.Errorf("UpdateDescription: %w", err)
 	}
 
+	// Validate the entity type is supported before choosing a path.
+	if _, err := LookupDescriptionAspect(entityType); err != nil {
+		return fmt.Errorf("UpdateDescription: %w", err)
+	}
+
+	// Domain, glossaryTerm, and glossaryNode do not support REST aspect writes
+	// for descriptions. Use the GraphQL updateDescription mutation instead.
+	if graphQLWriteTypes[entityType] {
+		return c.updateDescriptionGraphQL(ctx, urn, description)
+	}
+
+	return c.updateDescriptionREST(ctx, urn, description, entityType)
+}
+
+// updateDescriptionREST updates a description via REST read-modify-write.
+func (c *Client) updateDescriptionREST(ctx context.Context, urn, description, entityType string) error {
 	aspectInfo, err := LookupDescriptionAspect(entityType)
 	if err != nil {
 		return fmt.Errorf("UpdateDescription: %w", err)
@@ -226,7 +244,10 @@ type tagAssociation struct {
 	Tag string `json:"tag"`
 }
 
-// AddTag adds a tag to an entity using read-modify-write on the globalTags aspect.
+// AddTag adds a tag to an entity.
+// Uses GraphQL for domain, glossaryTerm, and glossaryNode entities because
+// the REST API does not register globalTags as an aspect for these types.
+// Uses REST read-modify-write for all other entity types.
 func (c *Client) AddTag(ctx context.Context, urn, tagURN string) error {
 	entityType, err := entityTypeFromURN(urn)
 	if err != nil {
@@ -235,6 +256,10 @@ func (c *Client) AddTag(ctx context.Context, urn, tagURN string) error {
 
 	if !globalTagsSupportedTypes[entityType] {
 		return fmt.Errorf("AddTag: %w: %s", ErrUnsupportedTagEntity, entityType)
+	}
+
+	if graphQLWriteTypes[entityType] {
+		return c.addTagGraphQL(ctx, urn, tagURN)
 	}
 
 	// Read current tags
@@ -261,7 +286,10 @@ func (c *Client) AddTag(ctx context.Context, urn, tagURN string) error {
 	})
 }
 
-// RemoveTag removes a tag from an entity using read-modify-write on the globalTags aspect.
+// RemoveTag removes a tag from an entity.
+// Uses GraphQL for domain, glossaryTerm, and glossaryNode entities because
+// the REST API does not register globalTags as an aspect for these types.
+// Uses REST read-modify-write for all other entity types.
 func (c *Client) RemoveTag(ctx context.Context, urn, tagURN string) error {
 	entityType, err := entityTypeFromURN(urn)
 	if err != nil {
@@ -270,6 +298,10 @@ func (c *Client) RemoveTag(ctx context.Context, urn, tagURN string) error {
 
 	if !globalTagsSupportedTypes[entityType] {
 		return fmt.Errorf("RemoveTag: %w: %s", ErrUnsupportedTagEntity, entityType)
+	}
+
+	if graphQLWriteTypes[entityType] {
+		return c.removeTagGraphQL(ctx, urn, tagURN)
 	}
 
 	// Read current tags
@@ -326,7 +358,10 @@ type termAssociation struct {
 	URN string `json:"urn"`
 }
 
-// AddGlossaryTerm adds a glossary term to an entity using read-modify-write.
+// AddGlossaryTerm adds a glossary term to an entity.
+// Uses GraphQL for domain, glossaryTerm, and glossaryNode entities because
+// the REST API does not register glossaryTerms as an aspect for these types.
+// Uses REST read-modify-write for all other entity types.
 func (c *Client) AddGlossaryTerm(ctx context.Context, urn, termURN string) error {
 	entityType, err := entityTypeFromURN(urn)
 	if err != nil {
@@ -335,6 +370,10 @@ func (c *Client) AddGlossaryTerm(ctx context.Context, urn, termURN string) error
 
 	if !glossaryTermsSupportedTypes[entityType] {
 		return fmt.Errorf("AddGlossaryTerm: %w: %s", ErrUnsupportedGlossaryTermEntity, entityType)
+	}
+
+	if graphQLWriteTypes[entityType] {
+		return c.addTermGraphQL(ctx, urn, termURN)
 	}
 
 	terms, err := c.readGlossaryTerms(ctx, entityType, urn)
@@ -360,7 +399,10 @@ func (c *Client) AddGlossaryTerm(ctx context.Context, urn, termURN string) error
 	})
 }
 
-// RemoveGlossaryTerm removes a glossary term from an entity using read-modify-write.
+// RemoveGlossaryTerm removes a glossary term from an entity.
+// Uses GraphQL for domain, glossaryTerm, and glossaryNode entities because
+// the REST API does not register glossaryTerms as an aspect for these types.
+// Uses REST read-modify-write for all other entity types.
 func (c *Client) RemoveGlossaryTerm(ctx context.Context, urn, termURN string) error {
 	entityType, err := entityTypeFromURN(urn)
 	if err != nil {
@@ -369,6 +411,10 @@ func (c *Client) RemoveGlossaryTerm(ctx context.Context, urn, termURN string) er
 
 	if !glossaryTermsSupportedTypes[entityType] {
 		return fmt.Errorf("RemoveGlossaryTerm: %w: %s", ErrUnsupportedGlossaryTermEntity, entityType)
+	}
+
+	if graphQLWriteTypes[entityType] {
+		return c.removeTermGraphQL(ctx, urn, termURN)
 	}
 
 	terms, err := c.readGlossaryTerms(ctx, entityType, urn)

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -164,7 +164,6 @@ func (c *Client) UpdateDescription(ctx context.Context, urn, description string)
 
 // updateDescriptionREST updates a description via REST read-modify-write.
 func (c *Client) updateDescriptionREST(ctx context.Context, urn, description, entityType string, aspectInfo DescriptionAspectInfo) error {
-
 	props, err := c.readEditableProperties(ctx, entityType, urn, aspectInfo.AspectName)
 	if err != nil {
 		return fmt.Errorf("UpdateDescription: %w", err)

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -148,7 +148,8 @@ func (c *Client) UpdateDescription(ctx context.Context, urn, description string)
 	}
 
 	// Validate the entity type is supported before choosing a path.
-	if _, err := LookupDescriptionAspect(entityType); err != nil {
+	aspectInfo, err := LookupDescriptionAspect(entityType)
+	if err != nil {
 		return fmt.Errorf("UpdateDescription: %w", err)
 	}
 
@@ -158,15 +159,11 @@ func (c *Client) UpdateDescription(ctx context.Context, urn, description string)
 		return c.updateDescriptionGraphQL(ctx, urn, description)
 	}
 
-	return c.updateDescriptionREST(ctx, urn, description, entityType)
+	return c.updateDescriptionREST(ctx, urn, description, entityType, aspectInfo)
 }
 
 // updateDescriptionREST updates a description via REST read-modify-write.
-func (c *Client) updateDescriptionREST(ctx context.Context, urn, description, entityType string) error {
-	aspectInfo, err := LookupDescriptionAspect(entityType)
-	if err != nil {
-		return fmt.Errorf("UpdateDescription: %w", err)
-	}
+func (c *Client) updateDescriptionREST(ctx context.Context, urn, description, entityType string, aspectInfo DescriptionAspectInfo) error {
 
 	props, err := c.readEditableProperties(ctx, entityType, urn, aspectInfo.AspectName)
 	if err != nil {

--- a/pkg/client/write_graphql.go
+++ b/pkg/client/write_graphql.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// GraphQL mutations for entity types where REST aspect writes are not supported.
+// Domain, glossaryTerm, and glossaryNode do not register globalTags, glossaryTerms,
+// or editable description aspects in the REST API. DataHub's GraphQL mutations
+// handle the entity-type routing internally.
+
+const (
+	// AddTagMutation adds a tag to any entity via GraphQL.
+	// Signature: addTag(input: TagAssociationInput!): Boolean.
+	AddTagMutation = `
+mutation addTag($input: TagAssociationInput!) {
+  addTag(input: $input)
+}
+`
+
+	// RemoveTagMutation removes a tag from any entity via GraphQL.
+	// Signature: removeTag(input: TagAssociationInput!): Boolean.
+	RemoveTagMutation = `
+mutation removeTag($input: TagAssociationInput!) {
+  removeTag(input: $input)
+}
+`
+
+	// AddTermMutation adds a glossary term to any entity via GraphQL.
+	// Signature: addTerm(input: TermAssociationInput!): Boolean.
+	AddTermMutation = `
+mutation addTerm($input: TermAssociationInput!) {
+  addTerm(input: $input)
+}
+`
+
+	// RemoveTermMutation removes a glossary term from any entity via GraphQL.
+	// Signature: removeTerm(input: TermAssociationInput!): Boolean.
+	RemoveTermMutation = `
+mutation removeTerm($input: TermAssociationInput!) {
+  removeTerm(input: $input)
+}
+`
+
+	// UpdateDescriptionMutation updates the description of any entity via GraphQL.
+	// Signature: updateDescription(input: DescriptionUpdateInput!): Boolean.
+	UpdateDescriptionMutation = `
+mutation updateDescription($input: DescriptionUpdateInput!) {
+  updateDescription(input: $input)
+}
+`
+)
+
+// graphQLWriteTypes lists entity types that require GraphQL mutations for write
+// operations because the REST API does not support their aspects (globalTags,
+// glossaryTerms, editable description).
+var graphQLWriteTypes = map[string]bool{
+	entityTypeDomain:       true,
+	entityTypeGlossaryTerm: true,
+	entityTypeGlossaryNode: true,
+}
+
+// addTagGraphQL adds a tag to an entity using the GraphQL addTag mutation.
+func (c *Client) addTagGraphQL(ctx context.Context, urn, tagURN string) error {
+	variables := map[string]any{
+		"input": map[string]any{
+			"tagUrn":      tagURN,
+			"resourceUrn": urn,
+		},
+	}
+
+	var response struct {
+		AddTag bool `json:"addTag"`
+	}
+
+	if err := c.Execute(ctx, AddTagMutation, variables, &response); err != nil {
+		return fmt.Errorf("addTagGraphQL: %w", err)
+	}
+
+	return nil
+}
+
+// removeTagGraphQL removes a tag from an entity using the GraphQL removeTag mutation.
+func (c *Client) removeTagGraphQL(ctx context.Context, urn, tagURN string) error {
+	variables := map[string]any{
+		"input": map[string]any{
+			"tagUrn":      tagURN,
+			"resourceUrn": urn,
+		},
+	}
+
+	var response struct {
+		RemoveTag bool `json:"removeTag"`
+	}
+
+	if err := c.Execute(ctx, RemoveTagMutation, variables, &response); err != nil {
+		return fmt.Errorf("removeTagGraphQL: %w", err)
+	}
+
+	return nil
+}
+
+// addTermGraphQL adds a glossary term to an entity using the GraphQL addTerm mutation.
+func (c *Client) addTermGraphQL(ctx context.Context, urn, termURN string) error {
+	variables := map[string]any{
+		"input": map[string]any{
+			"termUrn":     termURN,
+			"resourceUrn": urn,
+		},
+	}
+
+	var response struct {
+		AddTerm bool `json:"addTerm"`
+	}
+
+	if err := c.Execute(ctx, AddTermMutation, variables, &response); err != nil {
+		return fmt.Errorf("addTermGraphQL: %w", err)
+	}
+
+	return nil
+}
+
+// removeTermGraphQL removes a glossary term from an entity using the GraphQL removeTerm mutation.
+func (c *Client) removeTermGraphQL(ctx context.Context, urn, termURN string) error {
+	variables := map[string]any{
+		"input": map[string]any{
+			"termUrn":     termURN,
+			"resourceUrn": urn,
+		},
+	}
+
+	var response struct {
+		RemoveTerm bool `json:"removeTerm"`
+	}
+
+	if err := c.Execute(ctx, RemoveTermMutation, variables, &response); err != nil {
+		return fmt.Errorf("removeTermGraphQL: %w", err)
+	}
+
+	return nil
+}
+
+// updateDescriptionGraphQL updates an entity's description using the GraphQL mutation.
+func (c *Client) updateDescriptionGraphQL(ctx context.Context, urn, description string) error {
+	variables := map[string]any{
+		"input": map[string]any{
+			"description": description,
+			"resourceUrn": urn,
+		},
+	}
+
+	var response struct {
+		UpdateDescription bool `json:"updateDescription"`
+	}
+
+	if err := c.Execute(ctx, UpdateDescriptionMutation, variables, &response); err != nil {
+		return fmt.Errorf("updateDescriptionGraphQL: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/client/write_graphql_test.go
+++ b/pkg/client/write_graphql_test.go
@@ -1,0 +1,411 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// extractGraphQLInput decodes a GraphQL request body and returns the "input" variable.
+func extractGraphQLInput(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var req graphQLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("failed to decode GraphQL request: %v", err)
+	}
+	input, ok := req.Variables["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'input' variable to be a map, got %T", req.Variables["input"])
+	}
+	return input
+}
+
+func TestAddTagGraphQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		urn      string
+		tagURN   string
+		response string
+		wantErr  bool
+	}{
+		{
+			name:     "domain entity",
+			urn:      "urn:li:domain:engineering",
+			tagURN:   "urn:li:tag:PII",
+			response: `{"data": {"addTag": true}}`,
+		},
+		{
+			name:     "glossaryTerm entity",
+			urn:      "urn:li:glossaryTerm:revenue",
+			tagURN:   "urn:li:tag:Sensitive",
+			response: `{"data": {"addTag": true}}`,
+		},
+		{
+			name:     "glossaryNode entity",
+			urn:      "urn:li:glossaryNode:finance",
+			tagURN:   "urn:li:tag:PII",
+			response: `{"data": {"addTag": true}}`,
+		},
+		{
+			name:     "graphql error",
+			urn:      "urn:li:domain:engineering",
+			tagURN:   "urn:li:tag:PII",
+			response: `{"errors": [{"message": "tag not found"}]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				input := extractGraphQLInput(t, r)
+				if input["resourceUrn"] != tt.urn {
+					t.Errorf("resourceUrn = %v, want %v", input["resourceUrn"], tt.urn)
+				}
+				if input["tagUrn"] != tt.tagURN {
+					t.Errorf("tagUrn = %v, want %v", input["tagUrn"], tt.tagURN)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				logger:     NopLogger{},
+			}
+
+			err := c.AddTag(context.Background(), tt.urn, tt.tagURN)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRemoveTagGraphQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		urn      string
+		tagURN   string
+		response string
+		wantErr  bool
+	}{
+		{
+			name:     "domain entity",
+			urn:      "urn:li:domain:engineering",
+			tagURN:   "urn:li:tag:PII",
+			response: `{"data": {"removeTag": true}}`,
+		},
+		{
+			name:     "glossaryTerm entity",
+			urn:      "urn:li:glossaryTerm:revenue",
+			tagURN:   "urn:li:tag:Sensitive",
+			response: `{"data": {"removeTag": true}}`,
+		},
+		{
+			name:     "graphql error",
+			urn:      "urn:li:domain:engineering",
+			tagURN:   "urn:li:tag:PII",
+			response: `{"errors": [{"message": "tag not found"}]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				input := extractGraphQLInput(t, r)
+				if input["resourceUrn"] != tt.urn {
+					t.Errorf("resourceUrn = %v, want %v", input["resourceUrn"], tt.urn)
+				}
+				if input["tagUrn"] != tt.tagURN {
+					t.Errorf("tagUrn = %v, want %v", input["tagUrn"], tt.tagURN)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				logger:     NopLogger{},
+			}
+
+			err := c.RemoveTag(context.Background(), tt.urn, tt.tagURN)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddTermGraphQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		urn      string
+		termURN  string
+		response string
+		wantErr  bool
+	}{
+		{
+			name:     "domain entity",
+			urn:      "urn:li:domain:engineering",
+			termURN:  "urn:li:glossaryTerm:revenue",
+			response: `{"data": {"addTerm": true}}`,
+		},
+		{
+			name:     "glossaryTerm entity",
+			urn:      "urn:li:glossaryTerm:revenue",
+			termURN:  "urn:li:glossaryTerm:finance",
+			response: `{"data": {"addTerm": true}}`,
+		},
+		{
+			name:     "graphql error",
+			urn:      "urn:li:domain:engineering",
+			termURN:  "urn:li:glossaryTerm:revenue",
+			response: `{"errors": [{"message": "term not found"}]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				input := extractGraphQLInput(t, r)
+				if input["resourceUrn"] != tt.urn {
+					t.Errorf("resourceUrn = %v, want %v", input["resourceUrn"], tt.urn)
+				}
+				if input["termUrn"] != tt.termURN {
+					t.Errorf("termUrn = %v, want %v", input["termUrn"], tt.termURN)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				logger:     NopLogger{},
+			}
+
+			err := c.AddGlossaryTerm(context.Background(), tt.urn, tt.termURN)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRemoveTermGraphQL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		input := extractGraphQLInput(t, r)
+		if input["resourceUrn"] != "urn:li:domain:engineering" {
+			t.Errorf("resourceUrn = %v, want urn:li:domain:engineering", input["resourceUrn"])
+		}
+		if input["termUrn"] != "urn:li:glossaryTerm:revenue" {
+			t.Errorf("termUrn = %v, want urn:li:glossaryTerm:revenue", input["termUrn"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": {"removeTerm": true}}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.RemoveGlossaryTerm(context.Background(), "urn:li:domain:engineering", "urn:li:glossaryTerm:revenue")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateDescriptionGraphQL(t *testing.T) {
+	tests := []struct {
+		name        string
+		urn         string
+		description string
+		response    string
+		wantErr     bool
+	}{
+		{
+			name:        "domain entity",
+			urn:         "urn:li:domain:engineering",
+			description: "Engineering domain",
+			response:    `{"data": {"updateDescription": true}}`,
+		},
+		{
+			name:        "glossaryTerm entity",
+			urn:         "urn:li:glossaryTerm:revenue",
+			description: "Revenue metric definition",
+			response:    `{"data": {"updateDescription": true}}`,
+		},
+		{
+			name:        "glossaryNode entity",
+			urn:         "urn:li:glossaryNode:finance",
+			description: "Finance glossary node",
+			response:    `{"data": {"updateDescription": true}}`,
+		},
+		{
+			name:        "graphql error",
+			urn:         "urn:li:domain:engineering",
+			description: "Updated",
+			response:    `{"errors": [{"message": "entity not found"}]}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				input := extractGraphQLInput(t, r)
+				if input["resourceUrn"] != tt.urn {
+					t.Errorf("resourceUrn = %v, want %v", input["resourceUrn"], tt.urn)
+				}
+				if input["description"] != tt.description {
+					t.Errorf("description = %v, want %v", input["description"], tt.description)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				logger:     NopLogger{},
+			}
+
+			err := c.UpdateDescription(context.Background(), tt.urn, tt.description)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateDescription_DatasetStillUsesREST(t *testing.T) {
+	// Verify that dataset entities still use the REST path, not GraphQL.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// REST GET for reading current aspect
+			resp := aspectResponse{Value: json.RawMessage(`{"description":"old"}`)}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// REST POST — verify it's an ingestProposal, not a GraphQL mutation
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		// REST ingestProposal has "proposal" key; GraphQL has "query" key
+		if _, hasQuery := body["query"]; hasQuery {
+			t.Error("dataset description should use REST, not GraphQL")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.UpdateDescription(context.Background(),
+		"urn:li:dataset:(urn:li:dataPlatform:hive,testdb.table,PROD)",
+		"new description")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddTag_DatasetStillUsesREST(t *testing.T) {
+	// Verify that dataset entities still use the REST path for tags.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := aspectResponse{Value: json.RawMessage(`{"tags":[]}`)}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if _, hasQuery := body["query"]; hasQuery {
+			t.Error("dataset tag should use REST, not GraphQL")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.AddTag(context.Background(),
+		"urn:li:dataset:(urn:li:dataPlatform:hive,testdb.table,PROD)",
+		"urn:li:tag:PII")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGraphQLWriteTypes(t *testing.T) {
+	// Verify the graphQLWriteTypes map has the correct entries.
+	expected := []string{"domain", "glossaryTerm", "glossaryNode"}
+	for _, et := range expected {
+		if !graphQLWriteTypes[et] {
+			t.Errorf("expected %q in graphQLWriteTypes", et)
+		}
+	}
+	// Verify dataset is NOT in the map.
+	notExpected := []string{"dataset", "dashboard", "chart", "dataFlow", "dataJob", "container", "dataProduct"}
+	for _, et := range notExpected {
+		if graphQLWriteTypes[et] {
+			t.Errorf("did not expect %q in graphQLWriteTypes", et)
+		}
+	}
+}
+
+func TestMutationStrings(t *testing.T) {
+	// Verify mutation strings contain expected GraphQL patterns.
+	tests := []struct {
+		name     string
+		mutation string
+		contains string
+	}{
+		{"AddTag", AddTagMutation, "addTag(input: $input)"},
+		{"RemoveTag", RemoveTagMutation, "removeTag(input: $input)"},
+		{"AddTerm", AddTermMutation, "addTerm(input: $input)"},
+		{"RemoveTerm", RemoveTermMutation, "removeTerm(input: $input)"},
+		{"UpdateDescription", UpdateDescriptionMutation, "updateDescription(input: $input)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(tt.mutation, tt.contains) {
+				t.Errorf("mutation does not contain %q", tt.contains)
+			}
+		})
+	}
+}

--- a/pkg/client/write_test.go
+++ b/pkg/client/write_test.go
@@ -305,31 +305,29 @@ func TestAddTag_NoExistingTags(t *testing.T) {
 }
 
 func TestAddTag_DomainEntity(t *testing.T) {
+	// Domain entities use GraphQL addTag mutation instead of REST.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusNotFound)
-			return
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
 		}
-		proposal, aspectJSON := extractProposalWireFormat(t, r.Body)
-		if proposal["entityType"] != "domain" {
-			t.Errorf("entityType = %v, want domain", proposal["entityType"])
+		input, ok := req.Variables["input"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected input variable")
 		}
-		if proposal["aspectName"] != "globalTags" {
-			t.Errorf("aspectName = %v, want globalTags", proposal["aspectName"])
+		if input["tagUrn"] != "urn:li:tag:PII" {
+			t.Errorf("tagUrn = %v, want urn:li:tag:PII", input["tagUrn"])
 		}
-		var tags globalTagsAspect
-		if err := json.Unmarshal([]byte(aspectJSON), &tags); err != nil {
-			t.Fatalf("failed to unmarshal inner aspect: %v", err)
+		if input["resourceUrn"] != "urn:li:domain:engineering" {
+			t.Errorf("resourceUrn = %v, want urn:li:domain:engineering", input["resourceUrn"])
 		}
-		if len(tags.Tags) != 1 {
-			t.Errorf("expected 1 tag, got %d", len(tags.Tags))
-		}
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": {"addTag": true}}`))
 	}))
 	defer server.Close()
 
 	c := &Client{
-		endpoint:   server.URL + "/api/graphql",
+		endpoint:   server.URL,
 		token:      "test-token",
 		httpClient: server.Client(),
 		logger:     NopLogger{},


### PR DESCRIPTION
## Summary

Fixes #107 — four verified bugs in write operations against DataHub 1.4.x instances.

- **Bug 1: `UpsertStructuredProperties` wrong field name** — The GraphQL mutation input used `propertyUrn` (the REST API field name) instead of `structuredPropertyUrn` (the GraphQL field name), causing `field name 'propertyUrn' is not defined for input object type 'StructuredPropertyInputParams'`.

- **Bug 2: `ResolveIncident` wrong input type** — The mutation declared `$input: UpdateIncidentStatusInput!` but DataHub 1.4.x renamed the type to `IncidentStatusInput!`, causing `Variable 'input' of type 'UpdateIncidentStatusInput!' used in position expecting type 'IncidentStatusInput!'`.

- **Bug 3: Tags on domain/glossaryTerm/glossaryNode fail via REST** — The REST API does not register `globalTags` as a writable aspect for domain, glossaryTerm, or glossaryNode entities, causing `Unknown aspect globalTags for entity domain`. Now routes these entity types through GraphQL `addTag`/`removeTag` mutations instead.

- **Bug 4: Descriptions on domain/glossaryTerm/glossaryNode fail via REST** — Same root cause as Bug 3 but for description aspects (`domainProperties`, `glossaryTermInfo`, `glossaryNodeInfo`). The REST `ingestProposal` rejects these with 422 validation errors. Now routes these entity types through the GraphQL `updateDescription` mutation.

Additionally, glossary term association operations (`AddGlossaryTerm`/`RemoveGlossaryTerm`) for domain/glossaryTerm/glossaryNode are also routed through GraphQL `addTerm`/`removeTerm` mutations, since the REST `glossaryTerms` aspect has the same registration issue.

## Approach

For Bugs 1 & 2: single-line fixes to field/type names in GraphQL mutation strings.

For Bugs 3 & 4: introduced a `graphQLWriteTypes` map (`domain`, `glossaryTerm`, `glossaryNode`) and GraphQL mutation methods in a new `write_graphql.go` file. The public API (`AddTag`, `RemoveTag`, `AddGlossaryTerm`, `RemoveGlossaryTerm`, `UpdateDescription`) checks the entity type and routes to either the existing REST read-modify-write path or the new GraphQL mutation path. All other entity types (dataset, dashboard, chart, etc.) continue to use REST unchanged.

All GraphQL mutation signatures were verified against the official DataHub GraphQL schema (`datahub-graphql-core/src/main/resources/entity.graphql`):
- `addTag(input: TagAssociationInput!): Boolean`
- `removeTag(input: TagAssociationInput!): Boolean`
- `addTerm(input: TermAssociationInput!): Boolean`
- `removeTerm(input: TermAssociationInput!): Boolean`
- `updateDescription(input: DescriptionUpdateInput!): Boolean`

## Files changed

| File | Change |
|------|--------|
| `pkg/client/structured_properties.go` | `propertyUrn` → `structuredPropertyUrn` |
| `pkg/client/incidents.go` | `UpdateIncidentStatusInput!` → `IncidentStatusInput!` |
| `pkg/client/write.go` | Route domain/glossaryTerm/glossaryNode through GraphQL |
| `pkg/client/write_graphql.go` | **New** — GraphQL mutation constants and handler methods |
| `pkg/client/write_graphql_test.go` | **New** — 411 lines of tests for all GraphQL write paths |
| `pkg/client/write_test.go` | Updated `TestAddTag_DomainEntity` for GraphQL path |

## Verification matrix

| # | Operation | Entity Type | Before | After |
|---|-----------|-------------|--------|-------|
| 1 | `UpsertStructuredProperties` | dataset | `propertyUrn` not defined | Fixed field name |
| 2 | `ResolveIncident` | any | Wrong input type | Fixed type name |
| 3 | `AddTag` / `RemoveTag` | domain | Unknown aspect | GraphQL mutation |
| 4 | `AddTag` / `RemoveTag` | glossaryTerm | Unknown aspect | GraphQL mutation |
| 5 | `AddTag` / `RemoveTag` | glossaryNode | Unknown aspect | GraphQL mutation |
| 6 | `UpdateDescription` | domain | 422 validation error | GraphQL mutation |
| 7 | `UpdateDescription` | glossaryTerm | 422 validation error | GraphQL mutation |
| 8 | `UpdateDescription` | glossaryNode | 422 validation error | GraphQL mutation |
| 9 | `AddGlossaryTerm` / `RemoveGlossaryTerm` | domain/glossaryTerm/glossaryNode | Unknown aspect | GraphQL mutation |
| 10 | All write ops | dataset/dashboard/chart/etc. | Working (REST) | Unchanged (REST) |

## Test plan

- [x] `make verify` passes (lint, tests, coverage, mutation, security, deadcode, build)
- [x] All existing tests pass unchanged (REST paths for dataset/dashboard/etc.)
- [x] New tests verify GraphQL mutations send correct `resourceUrn`, `tagUrn`, `termUrn`, `description` fields
- [x] New tests verify dataset entities still route through REST (not GraphQL)
- [x] New tests verify GraphQL error propagation
- [ ] Integration test against live DataHub 1.4.x instance