### PR TITLE
fix: wrap structured property values in typed objects for GraphQL

### DIFF
--- a/pkg/client/structured_properties.go
+++ b/pkg/client/structured_properties.go
@@ -232,9 +232,13 @@ func (c *Client) ListStructuredPropertyDefinitions(ctx context.Context) ([]types
 func (c *Client) UpsertStructuredProperties(ctx context.Context, urn string, properties []types.StructuredPropertyInput) error {
 	propInputs := make([]map[string]any, 0, len(properties))
 	for _, p := range properties {
+		typedValues := make([]map[string]any, 0, len(p.Values))
+		for _, v := range p.Values {
+			typedValues = append(typedValues, toTypedPropertyValue(v))
+		}
 		propInputs = append(propInputs, map[string]any{
 			"structuredPropertyUrn": p.PropertyURN,
-			"values":                p.Values,
+			"values":                typedValues,
 		})
 	}
 
@@ -334,6 +338,27 @@ func (v propertyValueEntry) toAny() any {
 		return *v.NumberValue
 	}
 	return nil
+}
+
+// toTypedPropertyValue wraps a raw Go value in the typed map that the
+// DataHub UpsertStructuredProperties GraphQL mutation expects.
+// Strings become {"stringValue": v}, numbers become {"numberValue": v}.
+func toTypedPropertyValue(v any) map[string]any {
+	switch val := v.(type) {
+	case string:
+		return map[string]any{"stringValue": val}
+	case float64:
+		return map[string]any{"numberValue": val}
+	case float32:
+		return map[string]any{"numberValue": float64(val)}
+	case int:
+		return map[string]any{"numberValue": float64(val)}
+	case int64:
+		return map[string]any{"numberValue": float64(val)}
+	default:
+		// Fall back to stringValue for unknown types.
+		return map[string]any{"stringValue": fmt.Sprintf("%v", v)}
+	}
 }
 
 // toValue converts a GraphQL response entry to the domain type.

--- a/pkg/client/structured_properties_test.go
+++ b/pkg/client/structured_properties_test.go
@@ -563,6 +563,29 @@ func TestUpsertStructuredProperties(t *testing.T) {
 				if input["assetUrn"] != tt.urn {
 					t.Errorf("assetUrn = %v, want %v", input["assetUrn"], tt.urn)
 				}
+				// Verify values are wrapped in typed value objects
+				params, ok := input["structuredPropertyInputParams"].([]any)
+				if !ok {
+					t.Fatal("expected structuredPropertyInputParams in input")
+				}
+				for i, param := range params {
+					p := param.(map[string]any)
+					vals, ok := p["values"].([]any)
+					if !ok {
+						t.Fatalf("param[%d]: expected values array", i)
+					}
+					for j, val := range vals {
+						vm, ok := val.(map[string]any)
+						if !ok {
+							t.Fatalf("param[%d].values[%d]: expected typed value map, got %T", i, j, val)
+						}
+						_, hasStr := vm["stringValue"]
+						_, hasNum := vm["numberValue"]
+						if !hasStr && !hasNum {
+							t.Errorf("param[%d].values[%d]: expected stringValue or numberValue key", i, j)
+						}
+					}
+				}
 			}
 		})
 	}
@@ -675,6 +698,33 @@ func TestPropertyValueEntry_ToAny(t *testing.T) {
 			got := tt.entry.toAny()
 			if got != tt.want {
 				t.Errorf("toAny() = %v (type %T), want %v (type %T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestToTypedPropertyValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		wantKey string
+	}{
+		{name: "string", input: "hello", wantKey: "stringValue"},
+		{name: "float64", input: float64(42), wantKey: "numberValue"},
+		{name: "float32", input: float32(3.14), wantKey: "numberValue"},
+		{name: "int", input: 7, wantKey: "numberValue"},
+		{name: "int64", input: int64(99), wantKey: "numberValue"},
+		{name: "bool fallback", input: true, wantKey: "stringValue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toTypedPropertyValue(tt.input)
+			if _, ok := got[tt.wantKey]; !ok {
+				t.Errorf("toTypedPropertyValue(%v) missing key %q, got %v", tt.input, tt.wantKey, got)
+			}
+			if len(got) != 1 {
+				t.Errorf("toTypedPropertyValue(%v) should have exactly 1 key, got %d", tt.input, len(got))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- **Bug:** `UpsertStructuredProperties` passed raw values (e.g., `"2 years"`, `30`) in the `values` array, but DataHub's GraphQL API expects typed value objects (`{"stringValue": "..."}` or `{"numberValue": ...}`), causing `Expected type 'Map' but was 'String'` errors on `set_structured_property`
- **Fix:** Added `toTypedPropertyValue` helper that wraps each raw Go value in the appropriate typed map before building the GraphQL variables
- **Tests:** Added typed-value format assertions to existing upsert test + dedicated `TestToTypedPropertyValue` covering all type branches

## Test plan
- [x] `make verify` passes (all 43 linters, race tests, coverage, mutation, security)
- [ ] Verify `set_structured_property` succeeds against a live DataHub 1.4.x instance
- [ ] Verify `remove_structured_property` still works (no changes to that path)