### PR TITLE
fix: default context documents to visible and published

### DIFF
--- a/pkg/client/context_documents.go
+++ b/pkg/client/context_documents.go
@@ -154,15 +154,13 @@ func (c *Client) UpsertContextDocument(
 func (c *Client) createContextDocument(
 	ctx context.Context, entityURN string, doc types.ContextDocumentInput,
 ) (*types.ContextDocument, error) {
-	// GlobalContext defaults to false (zero value), which is intentional:
-	// context documents are entity-scoped and should not appear in global search.
-	// CreateDocument always sends the settings block, so false is explicit on the wire.
 	input := types.CreateDocumentInput{
 		Title:            doc.Title,
 		Content:          doc.Content,
 		SubType:          doc.Category,
 		RelatedAssetURNs: []string{entityURN},
 		Status:           "PUBLISHED",
+		GlobalContext:    true,
 	}
 
 	urn, err := c.CreateDocument(ctx, input)

--- a/pkg/client/context_documents_test.go
+++ b/pkg/client/context_documents_test.go
@@ -180,6 +180,10 @@ func TestUpsertContextDocument_Create(t *testing.T) {
 			if len(assets) != 1 {
 				t.Errorf("relatedAssets len = %d, want 1", len(assets))
 			}
+			settings, _ := input["settings"].(map[string]any)
+			if settings["showInGlobalContext"] != true {
+				t.Errorf("showInGlobalContext = %v, want true", settings["showInGlobalContext"])
+			}
 			_, _ = w.Write([]byte(`{"data": {"createDocument": "urn:li:document:new-1"}}`))
 
 		case strings.Contains(req.Query, "getDocument"):

--- a/pkg/tools/write_create.go
+++ b/pkg/tools/write_create.go
@@ -38,7 +38,7 @@ type CreateInput struct {
 	Status        string   `json:"status,omitempty" jsonschema_description:"Publication status: PUBLISHED or UNPUBLISHED (document only)"`
 	SubType       string   `json:"sub_type,omitempty" jsonschema_description:"Document sub-type (document only)"`
 	RelatedAssets []string `json:"related_assets,omitempty" jsonschema_description:"Related asset URNs (document only)"`
-	GlobalContext bool     `json:"global_context,omitempty" jsonschema_description:"Show in global search (document only)"`
+	GlobalContext *bool    `json:"global_context,omitempty" jsonschema_description:"Show in global search (document only, default: true)"`
 
 	// Structured property fields
 	QualifiedName string   `json:"qualified_name,omitempty" jsonschema_description:"Fully qualified name (structured_property)"`
@@ -167,13 +167,24 @@ func (t *Toolkit) handleCreateDocument(ctx context.Context, c DataHubClient, inp
 	if input.Name == "" {
 		return "", errRequired("name")
 	}
+
+	status := input.Status
+	if status == "" {
+		status = "PUBLISHED"
+	}
+
+	globalContext := true
+	if input.GlobalContext != nil {
+		globalContext = *input.GlobalContext
+	}
+
 	return c.CreateDocument(ctx, types.CreateDocumentInput{
 		Title:            input.Name,
 		Content:          input.Description,
-		Status:           input.Status,
+		Status:           status,
 		SubType:          input.SubType,
 		RelatedAssetURNs: input.RelatedAssets,
-		GlobalContext:    input.GlobalContext,
+		GlobalContext:    globalContext,
 	})
 }
 

--- a/pkg/tools/write_create_test.go
+++ b/pkg/tools/write_create_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"testing"
+
+	"github.com/txn2/mcp-datahub/pkg/types"
 )
 
 func TestHandleCreate_RequiresWhat(t *testing.T) {
@@ -64,6 +66,53 @@ func TestHandleCreate_AllTypes(t *testing.T) {
 				t.Errorf("action = %q, want created", typed.Action)
 			}
 		})
+	}
+}
+
+func TestHandleCreateDocument_Defaults(t *testing.T) {
+	mock := &mockClient{}
+	mock.createDocumentFunc = func(_ context.Context, input types.CreateDocumentInput) (string, error) {
+		if input.Status != "PUBLISHED" {
+			t.Errorf("Status = %q, want PUBLISHED", input.Status)
+		}
+		if !input.GlobalContext {
+			t.Error("GlobalContext = false, want true")
+		}
+		return "urn:li:document:test", nil
+	}
+
+	toolkit := NewToolkit(mock, Config{WriteEnabled: true})
+	result, _, _ := toolkit.handleCreate(context.Background(), nil, CreateInput{
+		What: "document",
+		Name: "Test Doc",
+	})
+	if result.IsError {
+		t.Errorf("unexpected error: %v", result)
+	}
+}
+
+func TestHandleCreateDocument_ExplicitOverrides(t *testing.T) {
+	mock := &mockClient{}
+	mock.createDocumentFunc = func(_ context.Context, input types.CreateDocumentInput) (string, error) {
+		if input.Status != "UNPUBLISHED" {
+			t.Errorf("Status = %q, want UNPUBLISHED", input.Status)
+		}
+		if input.GlobalContext {
+			t.Error("GlobalContext = true, want false")
+		}
+		return "urn:li:document:test", nil
+	}
+
+	toolkit := NewToolkit(mock, Config{WriteEnabled: true})
+	gcFalse := false
+	result, _, _ := toolkit.handleCreate(context.Background(), nil, CreateInput{
+		What:          "document",
+		Name:          "Draft Doc",
+		Status:        "UNPUBLISHED",
+		GlobalContext: &gcFalse,
+	})
+	if result.IsError {
+		t.Errorf("unexpected error: %v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Documents created via `UpsertContextDocument` and `datahub_create what=document` were invisible in the DataHub UI because `GlobalContext` defaulted to `false` (Go zero value) and `Status` defaulted to empty (server default: `UNPUBLISHED`)
- Both creation paths now default to `GlobalContext: true` and `Status: "PUBLISHED"`
- `GlobalContext` field on `CreateInput` changed from `bool` to `*bool` so callers can still explicitly pass `false`

Closes #122

## Changes

| File | Change |
|---|---|
| `pkg/client/context_documents.go` | Set `GlobalContext: true` in `createContextDocument` |
| `pkg/tools/write_create.go` | Default `Status` to `"PUBLISHED"` when empty; default `GlobalContext` to `true` via `*bool` (nil = true, explicit false respected) |
| `pkg/tools/write_create_test.go` | Added `TestHandleCreateDocument_Defaults` and `TestHandleCreateDocument_ExplicitOverrides` |
| `pkg/client/context_documents_test.go` | Added `showInGlobalContext: true` assertion in create test |

## Test plan

- [x] `make verify` passes clean
- [x] `TestHandleCreateDocument_Defaults` — verifies `Status=PUBLISHED`, `GlobalContext=true` when neither is provided
- [x] `TestHandleCreateDocument_ExplicitOverrides` — verifies `Status=UNPUBLISHED`, `GlobalContext=false` when explicitly set
- [x] `TestUpsertContextDocument_Create` — verifies `showInGlobalContext=true` is sent in the GraphQL mutation