### PR TITLE
feat: upgrade datahub_search to use searchAcrossEntities with filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ All are customizable via the three-tier priority pattern.
 
 | Tool | Title | Description |
 |------|-------|-------------|
-| `datahub_search` | Search Catalog | Search entities by query and type |
+| `datahub_search` | Search Catalog | Search entities with keyword or semantic mode; supports `types` for multi-type search and `filters` for advanced field-level filtering (fieldPaths, fieldTags, platform, etc.) via `searchAcrossEntities` |
 | `datahub_get_entity` | Get Entity | Get entity metadata by URN |
 | `datahub_get_schema` | Get Schema | Get dataset schema |
 | `datahub_get_lineage` | Get Lineage | Get upstream/downstream lineage; set `level=column` for column-level lineage |

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -369,7 +369,7 @@ func (c *Client) Search(ctx context.Context, query string, opts ...SearchOption)
 	// Default to DATASET if no entity type specified
 	entityType := options.entityType
 	if entityType == "" {
-		entityType = "DATASET"
+		entityType = DefaultEntityType
 	}
 
 	input := map[string]any{

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -13,6 +13,24 @@ type searchOptions struct {
 	limit      int
 	offset     int
 	filters    map[string][]string
+	types      []string
+	orFilters  []SearchFilter
+}
+
+// SearchFilter represents a single filter criterion for advanced search.
+// Filters are AND'd together within a single search request.
+type SearchFilter struct {
+	// Field is the filter field name (e.g., "fieldPaths", "fieldTags", "platform", "owners").
+	Field string
+
+	// Values are the values to match against.
+	Values []string
+
+	// Condition is the filter operator: CONTAIN, EQUAL (default), IN, EXISTS, etc.
+	Condition string
+
+	// Negated inverts the filter (exclude matching entities).
+	Negated bool
 }
 
 // toEnumCase converts camelCase or PascalCase strings to SCREAMING_SNAKE_CASE.
@@ -59,9 +77,33 @@ func WithOffset(offset int) SearchOption {
 }
 
 // WithFilters adds search filters.
+//
+// Deprecated: Use WithOrFilters for advanced filtering with searchAcrossEntities.
 func WithFilters(filters map[string][]string) SearchOption {
 	return func(o *searchOptions) {
 		o.filters = filters
+	}
+}
+
+// WithTypes sets the entity types to search across.
+// Valid types: DATASET, DASHBOARD, DATA_FLOW, DATA_JOB, CONTAINER, DOMAIN,
+// TAG, GLOSSARY_TERM, CORP_USER, CORP_GROUP, DATA_PRODUCT, etc.
+// Each type is normalized to SCREAMING_SNAKE_CASE.
+func WithTypes(types []string) SearchOption {
+	return func(o *searchOptions) {
+		normalized := make([]string, len(types))
+		for i, t := range types {
+			normalized[i] = toEnumCase(t)
+		}
+		o.types = normalized
+	}
+}
+
+// WithOrFilters sets advanced search filters.
+// Filters are AND'd together in a single filter group.
+func WithOrFilters(filters []SearchFilter) SearchOption {
+	return func(o *searchOptions) {
+		o.orFilters = filters
 	}
 }
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -130,6 +130,9 @@ func WithDepth(depth int) LineageOption {
 	}
 }
 
+// DefaultEntityType is the entity type used when none is specified.
+const DefaultEntityType = "DATASET"
+
 // Constants for lineage directions.
 const (
 	LineageDirectionUpstream   = "UPSTREAM"

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -78,7 +78,7 @@ func WithOffset(offset int) SearchOption {
 
 // WithFilters adds search filters.
 //
-// Deprecated: Use WithOrFilters for advanced filtering with searchAcrossEntities.
+// Deprecated: Use WithSearchFilters for advanced filtering with searchAcrossEntities.
 func WithFilters(filters map[string][]string) SearchOption {
 	return func(o *searchOptions) {
 		o.filters = filters
@@ -99,9 +99,9 @@ func WithTypes(types []string) SearchOption {
 	}
 }
 
-// WithOrFilters sets advanced search filters.
-// Filters are AND'd together in a single filter group.
-func WithOrFilters(filters []SearchFilter) SearchOption {
+// WithSearchFilters sets advanced search filters for searchAcrossEntities.
+// All filters are AND'd together (all conditions must match).
+func WithSearchFilters(filters []SearchFilter) SearchOption {
 	return func(o *searchOptions) {
 		o.orFilters = filters
 	}

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -90,6 +90,53 @@ func TestWithFilters(t *testing.T) {
 	}
 }
 
+func TestWithTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"already uppercase", []string{"DATASET", "DASHBOARD"}, []string{"DATASET", "DASHBOARD"}},
+		{"camelCase normalized", []string{"glossaryTerm", "dataProduct"}, []string{"GLOSSARY_TERM", "DATA_PRODUCT"}},
+		{"mixed case", []string{"DATASET", "glossaryTerm"}, []string{"DATASET", "GLOSSARY_TERM"}},
+		{"empty", []string{}, []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &searchOptions{}
+			WithTypes(tt.input)(opts)
+			if len(opts.types) != len(tt.want) {
+				t.Fatalf("WithTypes() count = %d, want %d", len(opts.types), len(tt.want))
+			}
+			for i, v := range opts.types {
+				if v != tt.want[i] {
+					t.Errorf("WithTypes()[%d] = %q, want %q", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestWithOrFilters(t *testing.T) {
+	opts := &searchOptions{}
+	filters := []SearchFilter{
+		{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
+		{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}, Negated: true},
+	}
+	WithOrFilters(filters)(opts)
+
+	if len(opts.orFilters) != 2 {
+		t.Fatalf("WithOrFilters() count = %d, want 2", len(opts.orFilters))
+	}
+	if opts.orFilters[0].Field != "fieldPaths" {
+		t.Errorf("filter[0].Field = %q, want fieldPaths", opts.orFilters[0].Field)
+	}
+	if opts.orFilters[1].Negated != true {
+		t.Error("filter[1].Negated should be true")
+	}
+}
+
 func TestLineageOptions(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -118,16 +118,16 @@ func TestWithTypes(t *testing.T) {
 	}
 }
 
-func TestWithOrFilters(t *testing.T) {
+func TestWithSearchFilters(t *testing.T) {
 	opts := &searchOptions{}
 	filters := []SearchFilter{
 		{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
 		{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}, Negated: true},
 	}
-	WithOrFilters(filters)(opts)
+	WithSearchFilters(filters)(opts)
 
 	if len(opts.orFilters) != 2 {
-		t.Fatalf("WithOrFilters() count = %d, want 2", len(opts.orFilters))
+		t.Fatalf("WithSearchFilters() count = %d, want 2", len(opts.orFilters))
 	}
 	if opts.orFilters[0].Field != "fieldPaths" {
 		t.Errorf("filter[0].Field = %q, want fieldPaths", opts.orFilters[0].Field)

--- a/pkg/client/search_across.go
+++ b/pkg/client/search_across.go
@@ -9,6 +9,7 @@ import (
 
 // SearchAcrossEntitiesQuery searches across multiple entity types with advanced filtering.
 // Uses the searchAcrossEntities GraphQL endpoint which supports orFilters and multi-type search.
+// Shared by both SearchAcrossEntities (keyword) and SemanticSearch (fulltext) methods.
 const SearchAcrossEntitiesQuery = `
 query searchAcrossEntities($input: SearchAcrossEntitiesInput!) {
   searchAcrossEntities(input: $input) {
@@ -123,6 +124,18 @@ query searchAcrossEntities($input: SearchAcrossEntitiesInput!) {
 // Supports multi-type search and field-level filters (e.g., fieldPaths, fieldTags, platform).
 // Available in DataHub 1.3.x+.
 func (c *Client) SearchAcrossEntities(ctx context.Context, query string, opts ...SearchOption) (*types.SearchResult, error) {
+	return c.doSearchAcrossEntities(ctx, "SearchAcrossEntities", query, nil, opts)
+}
+
+// doSearchAcrossEntities is the shared implementation for SearchAcrossEntities and SemanticSearch.
+// extraFlags are merged into the GraphQL input (e.g., searchFlags for fulltext mode).
+func (c *Client) doSearchAcrossEntities(
+	ctx context.Context,
+	caller string,
+	query string,
+	extraFlags map[string]any,
+	opts []SearchOption,
+) (*types.SearchResult, error) {
 	options := &searchOptions{
 		limit:  c.config.DefaultLimit,
 		offset: 0,
@@ -151,6 +164,10 @@ func (c *Client) SearchAcrossEntities(ctx context.Context, query string, opts ..
 		input["orFilters"] = buildOrFilters(options.orFilters)
 	}
 
+	for k, v := range extraFlags {
+		input[k] = v
+	}
+
 	variables := map[string]any{
 		"input": input,
 	}
@@ -165,7 +182,7 @@ func (c *Client) SearchAcrossEntities(ctx context.Context, query string, opts ..
 	}
 
 	if err := c.Execute(ctx, SearchAcrossEntitiesQuery, variables, &response); err != nil {
-		return nil, fmt.Errorf("SearchAcrossEntities(%q): %w", query, err)
+		return nil, fmt.Errorf("%s(%q): %w", caller, query, err)
 	}
 
 	result := &types.SearchResult{

--- a/pkg/client/search_across.go
+++ b/pkg/client/search_across.go
@@ -143,6 +143,8 @@ func (c *Client) SearchAcrossEntities(ctx context.Context, query string, opts ..
 
 	if len(options.types) > 0 {
 		input["types"] = options.types
+	} else if options.entityType != "" {
+		input["types"] = []string{options.entityType}
 	}
 
 	if len(options.orFilters) > 0 {

--- a/pkg/client/search_across.go
+++ b/pkg/client/search_across.go
@@ -1,0 +1,207 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/txn2/mcp-datahub/pkg/types"
+)
+
+// SearchAcrossEntitiesQuery searches across multiple entity types with advanced filtering.
+// Uses the searchAcrossEntities GraphQL endpoint which supports orFilters and multi-type search.
+const SearchAcrossEntitiesQuery = `
+query searchAcrossEntities($input: SearchAcrossEntitiesInput!) {
+  searchAcrossEntities(input: $input) {
+    start
+    count
+    total
+    searchResults {
+      entity {
+        urn
+        type
+        ... on Dataset {
+          name
+          description
+          platform {
+            name
+          }
+          ownership {
+            owners {
+              owner {
+                ... on CorpUser {
+                  urn
+                  username
+                }
+                ... on CorpGroup {
+                  urn
+                  name
+                }
+              }
+              type
+            }
+          }
+          tags {
+            tags {
+              tag {
+                urn
+                name
+                description
+              }
+            }
+          }
+          domain {
+            domain {
+              urn
+              properties {
+                name
+                description
+              }
+            }
+          }
+        }
+        ... on Dashboard {
+          dashboardId
+          info {
+            name
+            description
+          }
+          platform {
+            name
+          }
+        }
+        ... on DataFlow {
+          flowId
+          info {
+            name
+            description
+          }
+          platform {
+            name
+          }
+        }
+        ... on DataProduct {
+          properties {
+            name
+            description
+          }
+        }
+        ... on GlossaryTerm {
+          properties {
+            name
+            description
+          }
+        }
+        ... on Tag {
+          properties {
+            name
+            description
+          }
+        }
+        ... on Document {
+          subType
+          info {
+            title
+            contents {
+              text
+            }
+            status {
+              state
+            }
+          }
+        }
+      }
+      matchedFields {
+        name
+        value
+      }
+    }
+  }
+}
+`
+
+// SearchAcrossEntities searches across entity types with optional advanced filtering.
+// Supports multi-type search and field-level filters (e.g., fieldPaths, fieldTags, platform).
+// Available in DataHub 1.3.x+.
+func (c *Client) SearchAcrossEntities(ctx context.Context, query string, opts ...SearchOption) (*types.SearchResult, error) {
+	options := &searchOptions{
+		limit:  c.config.DefaultLimit,
+		offset: 0,
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.limit > c.config.MaxLimit {
+		options.limit = c.config.MaxLimit
+	}
+
+	input := map[string]any{
+		"query": query,
+		"start": options.offset,
+		"count": options.limit,
+	}
+
+	if len(options.types) > 0 {
+		input["types"] = options.types
+	}
+
+	if len(options.orFilters) > 0 {
+		input["orFilters"] = buildOrFilters(options.orFilters)
+	}
+
+	variables := map[string]any{
+		"input": input,
+	}
+
+	var response struct {
+		SearchAcrossEntities struct {
+			Start         int                `json:"start"`
+			Count         int                `json:"count"`
+			Total         int                `json:"total"`
+			SearchResults []searchResultItem `json:"searchResults"`
+		} `json:"searchAcrossEntities"`
+	}
+
+	if err := c.Execute(ctx, SearchAcrossEntitiesQuery, variables, &response); err != nil {
+		return nil, fmt.Errorf("SearchAcrossEntities(%q): %w", query, err)
+	}
+
+	result := &types.SearchResult{
+		Total:  response.SearchAcrossEntities.Total,
+		Offset: response.SearchAcrossEntities.Start,
+		Limit:  response.SearchAcrossEntities.Count,
+	}
+
+	for _, sr := range response.SearchAcrossEntities.SearchResults {
+		result.Entities = append(result.Entities, parseSearchResult(sr))
+	}
+
+	return result, nil
+}
+
+// buildOrFilters converts SearchFilter slices into the GraphQL orFilters structure.
+// All filters are AND'd together in a single filter group.
+func buildOrFilters(filters []SearchFilter) []map[string]any {
+	andConditions := make([]map[string]any, 0, len(filters))
+
+	for _, f := range filters {
+		condition := map[string]any{
+			"field":  f.Field,
+			"values": f.Values,
+		}
+
+		if f.Condition != "" {
+			condition["condition"] = f.Condition
+		}
+
+		if f.Negated {
+			condition["negated"] = true
+		}
+
+		andConditions = append(andConditions, condition)
+	}
+
+	return []map[string]any{
+		{"and": andConditions},
+	}
+}

--- a/pkg/client/search_across_test.go
+++ b/pkg/client/search_across_test.go
@@ -1,0 +1,385 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchAcrossEntities(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseJSON string
+		wantTotal    int
+		wantCount    int
+		wantErr      bool
+	}{
+		{
+			name: "results found",
+			responseJSON: `{
+				"data": {
+					"searchAcrossEntities": {
+						"start": 0,
+						"count": 10,
+						"total": 2,
+						"searchResults": [
+							{
+								"entity": {
+									"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,catalog.schema.users,PROD)",
+									"type": "DATASET",
+									"name": "users",
+									"description": "User accounts table",
+									"platform": {"name": "trino"}
+								},
+								"matchedFields": [{"name": "fieldPaths", "value": "email"}]
+							},
+							{
+								"entity": {
+									"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,catalog.schema.orders,PROD)",
+									"type": "DATASET",
+									"name": "orders",
+									"description": "Orders table",
+									"platform": {"name": "trino"}
+								},
+								"matchedFields": []
+							}
+						]
+					}
+				}
+			}`,
+			wantTotal: 2,
+			wantCount: 2,
+		},
+		{
+			name: "empty results",
+			responseJSON: `{
+				"data": {
+					"searchAcrossEntities": {
+						"start": 0,
+						"count": 10,
+						"total": 0,
+						"searchResults": []
+					}
+				}
+			}`,
+			wantTotal: 0,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.responseJSON))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				config:     DefaultConfig(),
+				logger:     NopLogger{},
+			}
+
+			result, err := c.SearchAcrossEntities(context.Background(), "test")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if result.Total != tt.wantTotal {
+				t.Errorf("Total = %d, want %d", result.Total, tt.wantTotal)
+			}
+			if len(result.Entities) != tt.wantCount {
+				t.Errorf("Entities count = %d, want %d", len(result.Entities), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestSearchAcrossEntities_WithFilters(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 1,
+					"searchResults": [{
+						"entity": {
+							"urn": "urn:li:dataset:test",
+							"type": "DATASET",
+							"name": "test"
+						},
+						"matchedFields": [{"name": "fieldPaths", "value": "email"}]
+					}]
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.SearchAcrossEntities(context.Background(), "*",
+		WithTypes([]string{"DATASET"}),
+		WithOrFilters([]SearchFilter{
+			{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
+			{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify types were sent
+	types, ok := capturedInput["types"].([]any)
+	if !ok || len(types) != 1 || types[0] != "DATASET" {
+		t.Errorf("types = %v, want [DATASET]", capturedInput["types"])
+	}
+
+	// Verify orFilters were sent
+	orFilters, ok := capturedInput["orFilters"].([]any)
+	if !ok || len(orFilters) != 1 {
+		t.Fatalf("orFilters = %v, want 1 group", capturedInput["orFilters"])
+	}
+
+	andGroup, ok := orFilters[0].(map[string]any)
+	if !ok {
+		t.Fatalf("orFilters[0] not a map")
+	}
+
+	andFilters, ok := andGroup["and"].([]any)
+	if !ok || len(andFilters) != 2 {
+		t.Fatalf("and filters = %v, want 2 filters", andGroup["and"])
+	}
+
+	firstFilter, _ := andFilters[0].(map[string]any)
+	if firstFilter["field"] != "fieldPaths" {
+		t.Errorf("first filter field = %v, want fieldPaths", firstFilter["field"])
+	}
+	if firstFilter["condition"] != "CONTAIN" {
+		t.Errorf("first filter condition = %v, want CONTAIN", firstFilter["condition"])
+	}
+}
+
+func TestSearchAcrossEntities_WithNegatedFilter(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.SearchAcrossEntities(context.Background(), "*",
+		WithOrFilters([]SearchFilter{
+			{Field: "tags", Values: []string{"urn:li:tag:deprecated"}, Negated: true},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	orFilters, ok := capturedInput["orFilters"].([]any)
+	if !ok || len(orFilters) != 1 {
+		t.Fatalf("orFilters = %v, want 1 group", capturedInput["orFilters"])
+	}
+	andGroup := orFilters[0].(map[string]any)
+	andFilters := andGroup["and"].([]any)
+	filter := andFilters[0].(map[string]any)
+
+	if filter["negated"] != true {
+		t.Errorf("negated = %v, want true", filter["negated"])
+	}
+}
+
+func TestSearchAcrossEntities_GraphQLError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors": [{"message": "search failed"}]}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.SearchAcrossEntities(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error on GraphQL error response")
+	}
+}
+
+func TestBuildOrFilters(t *testing.T) {
+	filters := []SearchFilter{
+		{Field: "fieldPaths", Values: []string{"email", "phone"}, Condition: "CONTAIN"},
+		{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}},
+		{Field: "tags", Values: []string{"urn:li:tag:deprecated"}, Negated: true},
+	}
+
+	result := buildOrFilters(filters)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 OR group, got %d", len(result))
+	}
+
+	andFilters, ok := result[0]["and"].([]map[string]any)
+	if !ok {
+		t.Fatal("expected 'and' key with []map[string]any")
+	}
+
+	if len(andFilters) != 3 {
+		t.Fatalf("expected 3 AND filters, got %d", len(andFilters))
+	}
+
+	// First filter: fieldPaths with CONTAIN
+	if andFilters[0]["field"] != "fieldPaths" {
+		t.Errorf("filter[0].field = %v, want fieldPaths", andFilters[0]["field"])
+	}
+	if andFilters[0]["condition"] != "CONTAIN" {
+		t.Errorf("filter[0].condition = %v, want CONTAIN", andFilters[0]["condition"])
+	}
+
+	// Second filter: platform without condition (omitted)
+	if _, hasCondition := andFilters[1]["condition"]; hasCondition {
+		t.Error("filter[1] should not have condition when empty")
+	}
+
+	// Third filter: negated
+	if andFilters[2]["negated"] != true {
+		t.Errorf("filter[2].negated = %v, want true", andFilters[2]["negated"])
+	}
+
+	// Non-negated filters should not have negated key
+	if _, hasNegated := andFilters[0]["negated"]; hasNegated {
+		t.Error("filter[0] should not have negated key when false")
+	}
+}
+
+func TestSearchAcrossEntities_EntityDetails(t *testing.T) {
+	responseJSON := `{
+		"data": {
+			"searchAcrossEntities": {
+				"start": 0,
+				"count": 10,
+				"total": 1,
+				"searchResults": [{
+					"entity": {
+						"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,catalog.schema.users,PROD)",
+						"type": "DATASET",
+						"name": "users",
+						"description": "User table",
+						"platform": {"name": "trino"},
+						"ownership": {
+							"owners": [{
+								"owner": {"urn": "urn:li:corpuser:admin", "username": "admin"},
+								"type": "DATAOWNER"
+							}]
+						},
+						"tags": {
+							"tags": [{"tag": {"urn": "urn:li:tag:pii", "name": "pii", "description": "PII data"}}]
+						},
+						"domain": {
+							"domain": {
+								"urn": "urn:li:domain:commerce",
+								"properties": {"name": "Commerce", "description": "Commerce domain"}
+							}
+						}
+					},
+					"matchedFields": [{"name": "fieldPaths", "value": "email"}]
+				}]
+			}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responseJSON))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	result, err := c.SearchAcrossEntities(context.Background(), "*",
+		WithOrFilters([]SearchFilter{
+			{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Entities) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(result.Entities))
+	}
+
+	e := result.Entities[0]
+	if e.Platform != "trino" {
+		t.Errorf("Platform = %q, want trino", e.Platform)
+	}
+	if len(e.Owners) != 1 {
+		t.Errorf("Owners count = %d, want 1", len(e.Owners))
+	}
+	if len(e.Tags) != 1 || e.Tags[0].Name != "pii" {
+		t.Errorf("Tags = %+v", e.Tags)
+	}
+	if e.Domain == nil || e.Domain.Name != "Commerce" {
+		t.Errorf("Domain = %+v", e.Domain)
+	}
+	if len(e.MatchedFields) != 1 || e.MatchedFields[0].Name != "fieldPaths" {
+		t.Errorf("MatchedFields = %+v", e.MatchedFields)
+	}
+}

--- a/pkg/client/search_across_test.go
+++ b/pkg/client/search_across_test.go
@@ -104,6 +104,97 @@ func TestSearchAcrossEntities(t *testing.T) {
 	}
 }
 
+func TestSearchAcrossEntities_WithEntityTypeFallback(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.SearchAcrossEntities(context.Background(), "test",
+		WithEntityType("DASHBOARD"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	types, ok := capturedInput["types"].([]any)
+	if !ok || len(types) != 1 || types[0] != "DASHBOARD" {
+		t.Errorf("types = %v, want [DASHBOARD]", capturedInput["types"])
+	}
+}
+
+func TestSearchAcrossEntities_TypesOverridesEntityType(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	// WithTypes should win over WithEntityType
+	_, err := c.SearchAcrossEntities(context.Background(), "test",
+		WithEntityType("TAG"),
+		WithTypes([]string{"DATASET", "DASHBOARD"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	types, ok := capturedInput["types"].([]any)
+	if !ok || len(types) != 2 {
+		t.Fatalf("types = %v, want [DATASET, DASHBOARD]", capturedInput["types"])
+	}
+	if types[0] != "DATASET" || types[1] != "DASHBOARD" {
+		t.Errorf("types = %v, want [DATASET, DASHBOARD]", types)
+	}
+}
+
 func TestSearchAcrossEntities_WithFilters(t *testing.T) {
 	var capturedInput map[string]any
 
@@ -144,7 +235,7 @@ func TestSearchAcrossEntities_WithFilters(t *testing.T) {
 
 	_, err := c.SearchAcrossEntities(context.Background(), "*",
 		WithTypes([]string{"DATASET"}),
-		WithOrFilters([]SearchFilter{
+		WithSearchFilters([]SearchFilter{
 			{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
 			{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}},
 		}),
@@ -215,7 +306,7 @@ func TestSearchAcrossEntities_WithNegatedFilter(t *testing.T) {
 	}
 
 	_, err := c.SearchAcrossEntities(context.Background(), "*",
-		WithOrFilters([]SearchFilter{
+		WithSearchFilters([]SearchFilter{
 			{Field: "tags", Values: []string{"urn:li:tag:deprecated"}, Negated: true},
 		}),
 	)
@@ -354,7 +445,7 @@ func TestSearchAcrossEntities_EntityDetails(t *testing.T) {
 	}
 
 	result, err := c.SearchAcrossEntities(context.Background(), "*",
-		WithOrFilters([]SearchFilter{
+		WithSearchFilters([]SearchFilter{
 			{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
 		}),
 	)

--- a/pkg/client/search_across_test.go
+++ b/pkg/client/search_across_test.go
@@ -104,6 +104,47 @@ func TestSearchAcrossEntities(t *testing.T) {
 	}
 }
 
+func TestSearchAcrossEntities_NoTypesSearchesAll(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	// No WithTypes, no WithEntityType — should search all types
+	_, err := c.SearchAcrossEntities(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, hasTypes := capturedInput["types"]; hasTypes {
+		t.Errorf("types should not be sent when unset, got %v", capturedInput["types"])
+	}
+}
+
 func TestSearchAcrossEntities_WithEntityTypeFallback(t *testing.T) {
 	var capturedInput map[string]any
 

--- a/pkg/client/semantic_search.go
+++ b/pkg/client/semantic_search.go
@@ -2,187 +2,23 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/txn2/mcp-datahub/pkg/types"
 )
 
-// GraphQL query for semantic/fulltext search (DataHub 1.3.x+).
-const (
-	// SemanticSearchQuery performs fulltext search across all entity types.
-	// Uses searchAcrossEntities with searchFlags.fulltext=true for broader
-	// natural language matching than the type-scoped search() query.
-	SemanticSearchQuery = `
-query semanticSearch($input: SearchAcrossEntitiesInput!) {
-  searchAcrossEntities(input: $input) {
-    start
-    count
-    total
-    searchResults {
-      entity {
-        urn
-        type
-        ... on Dataset {
-          name
-          description
-          platform {
-            name
-          }
-          ownership {
-            owners {
-              owner {
-                ... on CorpUser {
-                  urn
-                  username
-                }
-                ... on CorpGroup {
-                  urn
-                  name
-                }
-              }
-              type
-            }
-          }
-          tags {
-            tags {
-              tag {
-                urn
-                name
-                description
-              }
-            }
-          }
-          domain {
-            domain {
-              urn
-              properties {
-                name
-                description
-              }
-            }
-          }
-        }
-        ... on Dashboard {
-          dashboardId
-          info {
-            name
-            description
-          }
-          platform {
-            name
-          }
-        }
-        ... on DataFlow {
-          flowId
-          info {
-            name
-            description
-          }
-          platform {
-            name
-          }
-        }
-        ... on DataProduct {
-          properties {
-            name
-            description
-          }
-        }
-        ... on GlossaryTerm {
-          properties {
-            name
-            description
-          }
-        }
-        ... on Tag {
-          properties {
-            name
-            description
-          }
-        }
-        ... on Document {
-          subType
-          info {
-            title
-            contents {
-              text
-            }
-            status {
-              state
-            }
-          }
-        }
-      }
-      matchedFields {
-        name
-        value
-      }
-    }
-  }
+// SemanticSearchQuery is an alias for SearchAcrossEntitiesQuery.
+// SemanticSearch uses the same GraphQL query but adds searchFlags.fulltext=true.
+const SemanticSearchQuery = SearchAcrossEntitiesQuery
+
+// semanticSearchFlags are the extra flags passed to searchAcrossEntities for fulltext mode.
+var semanticSearchFlags = map[string]any{
+	"searchFlags": map[string]any{"fulltext": true},
 }
-`
-)
 
 // SemanticSearch performs fulltext search across entities.
 // Uses searchAcrossEntities with fulltext mode for broader natural language
 // matching. Returns an error (not empty results) when not supported because
 // the caller explicitly chose semantic mode and should know it's unavailable.
 func (c *Client) SemanticSearch(ctx context.Context, query string, opts ...SearchOption) (*types.SearchResult, error) {
-	options := &searchOptions{
-		limit:  c.config.DefaultLimit,
-		offset: 0,
-	}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	if options.limit > c.config.MaxLimit {
-		options.limit = c.config.MaxLimit
-	}
-
-	input := map[string]any{
-		"query":       query,
-		"start":       options.offset,
-		"count":       options.limit,
-		"searchFlags": map[string]any{"fulltext": true},
-	}
-
-	if len(options.types) > 0 {
-		input["types"] = options.types
-	} else if options.entityType != "" {
-		input["types"] = []string{options.entityType}
-	}
-
-	if len(options.orFilters) > 0 {
-		input["orFilters"] = buildOrFilters(options.orFilters)
-	}
-
-	variables := map[string]any{
-		"input": input,
-	}
-
-	var response struct {
-		SearchAcrossEntities struct {
-			Start         int                `json:"start"`
-			Count         int                `json:"count"`
-			Total         int                `json:"total"`
-			SearchResults []searchResultItem `json:"searchResults"`
-		} `json:"searchAcrossEntities"`
-	}
-
-	if err := c.Execute(ctx, SemanticSearchQuery, variables, &response); err != nil {
-		return nil, fmt.Errorf("SemanticSearch(%q): %w", query, err)
-	}
-
-	result := &types.SearchResult{
-		Total:  response.SearchAcrossEntities.Total,
-		Offset: response.SearchAcrossEntities.Start,
-		Limit:  response.SearchAcrossEntities.Count,
-	}
-
-	for _, sr := range response.SearchAcrossEntities.SearchResults {
-		result.Entities = append(result.Entities, parseSearchResult(sr))
-	}
-
-	return result, nil
+	return c.doSearchAcrossEntities(ctx, "SemanticSearch", query, semanticSearchFlags, opts)
 }

--- a/pkg/client/semantic_search.go
+++ b/pkg/client/semantic_search.go
@@ -72,6 +72,16 @@ query semanticSearch($input: SearchAcrossEntitiesInput!) {
             name
           }
         }
+        ... on DataFlow {
+          flowId
+          info {
+            name
+            description
+          }
+          platform {
+            name
+          }
+        }
         ... on DataProduct {
           properties {
             name
@@ -82,6 +92,24 @@ query semanticSearch($input: SearchAcrossEntitiesInput!) {
           properties {
             name
             description
+          }
+        }
+        ... on Tag {
+          properties {
+            name
+            description
+          }
+        }
+        ... on Document {
+          subType
+          info {
+            title
+            contents {
+              text
+            }
+            status {
+              state
+            }
           }
         }
       }
@@ -119,8 +147,14 @@ func (c *Client) SemanticSearch(ctx context.Context, query string, opts ...Searc
 		"searchFlags": map[string]any{"fulltext": true},
 	}
 
-	if options.entityType != "" {
+	if len(options.types) > 0 {
+		input["types"] = options.types
+	} else if options.entityType != "" {
 		input["types"] = []string{options.entityType}
+	}
+
+	if len(options.orFilters) > 0 {
+		input["orFilters"] = buildOrFilters(options.orFilters)
 	}
 
 	variables := map[string]any{

--- a/pkg/client/semantic_search_test.go
+++ b/pkg/client/semantic_search_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -257,5 +259,64 @@ func TestSemanticSearch_DataProductProperties(t *testing.T) {
 	}
 	if e.Description != "Product description" {
 		t.Errorf("Description = %q", e.Description)
+	}
+}
+
+func TestSemanticSearch_WithTypesAndFilters(t *testing.T) {
+	var capturedInput map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if variables, ok := req["variables"].(map[string]any); ok {
+			capturedInput, _ = variables["input"].(map[string]any)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	_, err := c.SemanticSearch(context.Background(), "user data",
+		WithTypes([]string{"DATASET", "DASHBOARD"}),
+		WithSearchFilters([]SearchFilter{
+			{Field: "platform", Values: []string{"urn:li:dataPlatform:trino"}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify types were sent
+	types, ok := capturedInput["types"].([]any)
+	if !ok || len(types) != 2 {
+		t.Fatalf("types = %v, want [DATASET, DASHBOARD]", capturedInput["types"])
+	}
+
+	// Verify orFilters were sent
+	orFilters, ok := capturedInput["orFilters"].([]any)
+	if !ok || len(orFilters) != 1 {
+		t.Fatalf("orFilters = %v, want 1 group", capturedInput["orFilters"])
+	}
+
+	// Verify fulltext flag is still set
+	flags, ok := capturedInput["searchFlags"].(map[string]any)
+	if !ok || flags["fulltext"] != true {
+		t.Errorf("searchFlags = %v, want fulltext: true", capturedInput["searchFlags"])
 	}
 }

--- a/pkg/tools/client_interface.go
+++ b/pkg/tools/client_interface.go
@@ -122,6 +122,11 @@ type DataHubClient interface {
 	// GetDataContract retrieves the data contract status for a dataset.
 	GetDataContract(ctx context.Context, datasetURN string) (*types.DataContract, error)
 
+	// Advanced search (DataHub 1.3.x+).
+
+	// SearchAcrossEntities searches across entity types with optional advanced filtering.
+	SearchAcrossEntities(ctx context.Context, query string, opts ...client.SearchOption) (*types.SearchResult, error)
+
 	// Semantic search (DataHub 1.4.x + OpenSearch 2.19.3+).
 
 	// SemanticSearch performs natural language semantic search across entities.

--- a/pkg/tools/context_test.go
+++ b/pkg/tools/context_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -13,7 +14,7 @@ func TestNewToolContext(t *testing.T) {
 		t.Errorf("NewToolContext() ToolName = %v, want %v", tc.ToolName, ToolSearch)
 	}
 
-	if tc.Input != input {
+	if !reflect.DeepEqual(tc.Input, input) {
 		t.Errorf("NewToolContext() Input mismatch")
 	}
 

--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -7,8 +7,10 @@ var defaultDescriptions = map[ToolName]string{
 		"This should be your FIRST tool when answering data questions — use it to discover " +
 		"relevant datasets before querying. Results include query_context showing which datasets " +
 		"are queryable in Trino and their resolved table paths. Search by topic keywords, " +
-		"table names, tags, or domain concepts. Follow up with datahub_get_schema or " +
-		"trino_describe_table for column details.",
+		"table names, tags, or domain concepts. Supports advanced filtering via 'filters' parameter " +
+		"to search by column names (fieldPaths), column tags (fieldTags), column glossary terms " +
+		"(fieldGlossaryTerms), platform, domain, owner, and more. Use 'types' to search across " +
+		"multiple entity types. Follow up with datahub_get_schema or trino_describe_table for column details.",
 
 	ToolGetEntity: "Get comprehensive metadata for a DataHub entity including description, owners, tags, " +
 		"glossary terms, domain, deprecation status, quality score, and custom properties. " +

--- a/pkg/tools/integration_test.go
+++ b/pkg/tools/integration_test.go
@@ -14,7 +14,7 @@ import (
 // createTestMockClient returns a mock client with all methods stubbed.
 func createTestMockClient() *mockClient {
 	return &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{Total: 1, Entities: []types.SearchEntity{{URN: "urn:li:dataset:test"}}}, nil
 		},
 		getEntityFunc: func(_ context.Context, urn string) (*types.Entity, error) {

--- a/pkg/tools/query_provider_test.go
+++ b/pkg/tools/query_provider_test.go
@@ -85,7 +85,7 @@ func extractResultText(t *testing.T, result *mcp.CallToolResult) string {
 
 func TestHandleSearch_WithQueryProvider(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Entities: []types.SearchEntity{
 					{URN: "urn:li:dataset:1", Name: "Table1"},
@@ -130,7 +130,7 @@ func TestHandleSearch_WithQueryProvider(t *testing.T) {
 
 func TestHandleSearch_WithQueryProvider_NoResults(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{Entities: []types.SearchEntity{}, Total: 0}, nil
 		},
 	}
@@ -157,7 +157,7 @@ func TestHandleSearch_WithQueryProvider_NoResults(t *testing.T) {
 
 func TestHandleSearch_WithQueryProvider_Error(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Entities: []types.SearchEntity{{URN: "urn:li:dataset:1"}},
 				Total:    1,
@@ -186,7 +186,7 @@ func TestHandleSearch_WithQueryProvider_Error(t *testing.T) {
 
 func TestHandleSearch_WithoutQueryProvider(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Entities: []types.SearchEntity{{URN: "urn:li:dataset:1"}},
 				Total:    1,

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -12,16 +12,34 @@ import (
 // SearchInput is the input for the search tool.
 type SearchInput struct {
 	Query string `json:"query" jsonschema_description:"Search query string"`
-	// EntityType: DATASET, DASHBOARD, DATA_FLOW, DATA_JOB, CONTAINER, TAG, GLOSSARY_TERM, DATA_PRODUCT, etc.
-	EntityType string `json:"entity_type,omitempty" jsonschema_description:"Entity type to search. Defaults to DATASET."`
-	Limit      int    `json:"limit,omitempty" jsonschema_description:"Maximum number of results (default: 10, max: 100)"`
-	Offset     int    `json:"offset,omitempty" jsonschema_description:"Result offset for pagination"`
+	// EntityType: DATASET, DASHBOARD, DATA_FLOW, DATA_JOB, CONTAINER, etc.
+	EntityType string `json:"entity_type,omitempty" jsonschema_description:"Entity type (single). Defaults to DATASET."`
+	// Types allows searching across multiple entity types. Overrides entity_type.
+	Types []string `json:"types,omitempty" jsonschema_description:"Entity types to search across. Overrides entity_type."`
+	// Filters enable advanced field-level filtering via searchAcrossEntities.
+	Filters []SearchFilterInput `json:"filters,omitempty" jsonschema_description:"Advanced field-level filters (AND'd together)."`
+	Limit   int                 `json:"limit,omitempty" jsonschema_description:"Maximum number of results (default: 10, max: 100)"`
+	Offset  int                 `json:"offset,omitempty" jsonschema_description:"Result offset for pagination"`
 	// Mode selects the search strategy: "keyword" (default) or "semantic".
 	// Semantic search uses vector embeddings for natural language queries.
 	// Requires DataHub 1.4.x with OpenSearch 2.19.3+.
 	Mode string `json:"mode,omitempty" jsonschema_description:"Search mode: keyword (default) or semantic"`
 	// Connection is the named connection to use. Empty uses the default connection.
 	Connection string `json:"connection,omitempty" jsonschema_description:"Named connection to use (see datahub_list_connections)"`
+}
+
+// SearchFilterInput represents a single filter criterion for advanced search.
+type SearchFilterInput struct {
+	// Field is the filter field name.
+	Field string `json:"field" jsonschema_description:"Filter field name (see tool description for options)"`
+	// Value is a convenience field for a single value. Use values for multiple.
+	Value string `json:"value,omitempty" jsonschema_description:"Single filter value. Use 'values' for multiple."`
+	// Values are the values to match against.
+	Values []string `json:"values,omitempty" jsonschema_description:"Filter values to match against"`
+	// Condition is the filter operator. Defaults to EQUAL if omitted.
+	Condition string `json:"condition,omitempty" jsonschema_description:"Filter operator: CONTAIN, EQUAL (default), IN, EXISTS"`
+	// Negated inverts the filter to exclude matches.
+	Negated bool `json:"negated,omitempty" jsonschema_description:"If true, exclude entities matching this filter"`
 }
 
 func (t *Toolkit) registerSearchTool(server *mcp.Server, cfg *toolConfig) {
@@ -47,12 +65,9 @@ func (t *Toolkit) registerSearchTool(server *mcp.Server, cfg *toolConfig) {
 	})
 }
 
-// buildSearchOptions constructs SearchOptions from input parameters.
+// buildSearchOptions constructs base SearchOptions (limit/offset) from input parameters.
 func buildSearchOptions(input SearchInput) []client.SearchOption {
 	var opts []client.SearchOption
-	if input.EntityType != "" {
-		opts = append(opts, client.WithEntityType(input.EntityType))
-	}
 	if input.Limit > 0 {
 		opts = append(opts, client.WithLimit(input.Limit))
 	}
@@ -60,6 +75,36 @@ func buildSearchOptions(input SearchInput) []client.SearchOption {
 		opts = append(opts, client.WithOffset(input.Offset))
 	}
 	return opts
+}
+
+// resolveSearchTypes determines the entity types to search.
+// Priority: types > entity_type > default (DATASET).
+func resolveSearchTypes(input SearchInput) []string {
+	if len(input.Types) > 0 {
+		return input.Types
+	}
+	if input.EntityType != "" {
+		return []string{input.EntityType}
+	}
+	return []string{"DATASET"}
+}
+
+// convertFilters converts tool-layer filter inputs to client-layer SearchFilter values.
+func convertFilters(inputs []SearchFilterInput) []client.SearchFilter {
+	filters := make([]client.SearchFilter, 0, len(inputs))
+	for _, f := range inputs {
+		values := f.Values
+		if f.Value != "" && len(values) == 0 {
+			values = []string{f.Value}
+		}
+		filters = append(filters, client.SearchFilter{
+			Field:     f.Field,
+			Values:    values,
+			Condition: f.Condition,
+			Negated:   f.Negated,
+		})
+	}
+	return filters
 }
 
 func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {
@@ -76,11 +121,19 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 		return ErrorResult("Connection error: " + err.Error()), nil, nil
 	}
 
+	opts := buildSearchOptions(input)
+	searchTypes := resolveSearchTypes(input)
+	opts = append(opts, client.WithTypes(searchTypes))
+
+	if len(input.Filters) > 0 {
+		opts = append(opts, client.WithOrFilters(convertFilters(input.Filters)))
+	}
+
 	var result *types.SearchResult
 	if input.Mode == "semantic" {
-		result, err = datahubClient.SemanticSearch(ctx, input.Query, buildSearchOptions(input)...)
+		result, err = datahubClient.SemanticSearch(ctx, input.Query, opts...)
 	} else {
-		result, err = datahubClient.Search(ctx, input.Query, buildSearchOptions(input)...)
+		result, err = datahubClient.SearchAcrossEntities(ctx, input.Query, opts...)
 	}
 	if err != nil {
 		return ErrorResult(err.Error()), nil, nil

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -87,7 +87,7 @@ func resolveSearchTypes(input SearchInput) []string {
 	if input.EntityType != "" {
 		return []string{input.EntityType}
 	}
-	return []string{"DATASET"}
+	return []string{client.DefaultEntityType}
 }
 
 // validateFilters checks that all filter inputs have a non-empty field and at least one value.
@@ -104,11 +104,12 @@ func validateFilters(filters []SearchFilterInput) error {
 }
 
 // convertFilters converts tool-layer filter inputs to client-layer SearchFilter values.
+// When both Value and Values are set, Value is prepended unless already present in Values.
 func convertFilters(inputs []SearchFilterInput) []client.SearchFilter {
 	filters := make([]client.SearchFilter, 0, len(inputs))
 	for _, f := range inputs {
 		values := f.Values
-		if f.Value != "" {
+		if f.Value != "" && !containsString(values, f.Value) {
 			values = append([]string{f.Value}, values...)
 		}
 		filters = append(filters, client.SearchFilter{
@@ -119,6 +120,15 @@ func convertFilters(inputs []SearchFilterInput) []client.SearchFilter {
 		})
 	}
 	return filters
+}
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -89,13 +90,26 @@ func resolveSearchTypes(input SearchInput) []string {
 	return []string{"DATASET"}
 }
 
+// validateFilters checks that all filter inputs have a non-empty field and at least one value.
+func validateFilters(filters []SearchFilterInput) error {
+	for i, f := range filters {
+		if f.Field == "" {
+			return fmt.Errorf("filter[%d]: field is required", i)
+		}
+		if f.Value == "" && len(f.Values) == 0 {
+			return fmt.Errorf("filter[%d] (%s): value or values is required", i, f.Field)
+		}
+	}
+	return nil
+}
+
 // convertFilters converts tool-layer filter inputs to client-layer SearchFilter values.
 func convertFilters(inputs []SearchFilterInput) []client.SearchFilter {
 	filters := make([]client.SearchFilter, 0, len(inputs))
 	for _, f := range inputs {
 		values := f.Values
-		if f.Value != "" && len(values) == 0 {
-			values = []string{f.Value}
+		if f.Value != "" {
+			values = append([]string{f.Value}, values...)
 		}
 		filters = append(filters, client.SearchFilter{
 			Field:     f.Field,
@@ -116,6 +130,10 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 		return ErrorResult("invalid mode: must be 'keyword' or 'semantic'"), nil, nil
 	}
 
+	if err := validateFilters(input.Filters); err != nil {
+		return ErrorResult(err.Error()), nil, nil
+	}
+
 	datahubClient, err := t.getClient(input.Connection)
 	if err != nil {
 		return ErrorResult("Connection error: " + err.Error()), nil, nil
@@ -126,7 +144,7 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 	opts = append(opts, client.WithTypes(searchTypes))
 
 	if len(input.Filters) > 0 {
-		opts = append(opts, client.WithOrFilters(convertFilters(input.Filters)))
+		opts = append(opts, client.WithSearchFilters(convertFilters(input.Filters)))
 	}
 
 	var result *types.SearchResult

--- a/pkg/tools/search_test.go
+++ b/pkg/tools/search_test.go
@@ -307,6 +307,13 @@ func TestConvertFilters(t *testing.T) {
 			},
 			wantLen: 1,
 		},
+		{
+			name: "value already in values is not duplicated",
+			inputs: []SearchFilterInput{
+				{Field: "fieldPaths", Value: "email", Values: []string{"email", "phone"}},
+			},
+			wantLen: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,6 +345,19 @@ func TestConvertFilters(t *testing.T) {
 				want := []string{"email", "phone", "address"}
 				if len(got[0].Values) != 3 {
 					t.Fatalf("expected 3 values, got %d: %v", len(got[0].Values), got[0].Values)
+				}
+				for i, v := range got[0].Values {
+					if v != want[i] {
+						t.Errorf("values[%d] = %q, want %q", i, v, want[i])
+					}
+				}
+			}
+
+			// Verify duplicate is not added
+			if tt.name == "value already in values is not duplicated" {
+				want := []string{"email", "phone"}
+				if len(got[0].Values) != 2 {
+					t.Fatalf("expected 2 values, got %d: %v", len(got[0].Values), got[0].Values)
 				}
 				for i, v := range got[0].Values {
 					if v != want[i] {

--- a/pkg/tools/search_test.go
+++ b/pkg/tools/search_test.go
@@ -102,6 +102,22 @@ func TestHandleSearch(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "filter with empty field",
+			input: SearchInput{
+				Query:   "*",
+				Filters: []SearchFilterInput{{Field: "", Value: "trino"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "filter with no values",
+			input: SearchInput{
+				Query:   "*",
+				Filters: []SearchFilterInput{{Field: "platform"}},
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid mode",
 			input: SearchInput{
 				Query: "test",
@@ -284,6 +300,13 @@ func TestConvertFilters(t *testing.T) {
 			},
 			wantLen: 1,
 		},
+		{
+			name: "both value and values merges all",
+			inputs: []SearchFilterInput{
+				{Field: "fieldPaths", Value: "email", Values: []string{"phone", "address"}},
+			},
+			wantLen: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -308,6 +331,70 @@ func TestConvertFilters(t *testing.T) {
 				if !got[0].Negated {
 					t.Error("negated should be true")
 				}
+			}
+
+			// Verify both value+values are merged
+			if tt.name == "both value and values merges all" {
+				want := []string{"email", "phone", "address"}
+				if len(got[0].Values) != 3 {
+					t.Fatalf("expected 3 values, got %d: %v", len(got[0].Values), got[0].Values)
+				}
+				for i, v := range got[0].Values {
+					if v != want[i] {
+						t.Errorf("values[%d] = %q, want %q", i, v, want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []SearchFilterInput
+		wantErr bool
+	}{
+		{
+			name:    "nil filters",
+			filters: nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid filter with value",
+			filters: []SearchFilterInput{{Field: "platform", Value: "trino"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid filter with values",
+			filters: []SearchFilterInput{{Field: "fieldPaths", Values: []string{"email"}}},
+			wantErr: false,
+		},
+		{
+			name:    "empty field",
+			filters: []SearchFilterInput{{Field: "", Value: "trino"}},
+			wantErr: true,
+		},
+		{
+			name:    "empty value and values",
+			filters: []SearchFilterInput{{Field: "platform"}},
+			wantErr: true,
+		},
+		{
+			name: "second filter invalid",
+			filters: []SearchFilterInput{
+				{Field: "platform", Value: "trino"},
+				{Field: ""},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFilters(tt.filters)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFilters() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/tools/search_test.go
+++ b/pkg/tools/search_test.go
@@ -69,12 +69,52 @@ func TestHandleSearch(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "with types override",
+			input: SearchInput{
+				Query: "revenue",
+				Types: []string{"DATASET", "DASHBOARD"},
+			},
+			mockResult: &types.SearchResult{
+				Total: 2,
+				Entities: []types.SearchEntity{
+					{URN: "urn:li:dataset:rev", Name: "revenue", Type: "DATASET"},
+					{URN: "urn:li:dashboard:rev", Name: "revenue-dash", Type: "DASHBOARD"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with filters",
+			input: SearchInput{
+				Query: "*",
+				Filters: []SearchFilterInput{
+					{Field: "fieldPaths", Values: []string{"email"}, Condition: "CONTAIN"},
+					{Field: "platform", Value: "urn:li:dataPlatform:trino"},
+				},
+			},
+			mockResult: &types.SearchResult{
+				Total: 1,
+				Entities: []types.SearchEntity{
+					{URN: "urn:li:dataset:users", Name: "users"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid mode",
+			input: SearchInput{
+				Query: "test",
+				Mode:  "invalid",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockClient{
-				searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+				searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 					if tt.mockErr != nil {
 						return nil, tt.mockErr
 					}
@@ -98,6 +138,57 @@ func TestHandleSearch(t *testing.T) {
 	}
 }
 
+func TestHandleSearch_SemanticMode(t *testing.T) {
+	semanticCalled := false
+	mock := &mockClient{
+		semanticSearchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			semanticCalled = true
+			return &types.SearchResult{Total: 1}, nil
+		},
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			t.Error("SearchAcrossEntities should not be called in semantic mode")
+			return &types.SearchResult{}, nil
+		},
+	}
+
+	toolkit := NewToolkit(mock, DefaultConfig())
+	result, _, _ := toolkit.handleSearch(context.Background(), nil, SearchInput{
+		Query: "test",
+		Mode:  "semantic",
+	})
+
+	if result.IsError {
+		t.Error("handleSearch() should not return error result")
+	}
+	if !semanticCalled {
+		t.Error("SemanticSearch should have been called")
+	}
+}
+
+func TestHandleSearch_KeywordUsesSearchAcrossEntities(t *testing.T) {
+	acrossCalled := false
+	mock := &mockClient{
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			acrossCalled = true
+			return &types.SearchResult{Total: 0}, nil
+		},
+		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			t.Error("Search should not be called for keyword mode")
+			return &types.SearchResult{}, nil
+		},
+	}
+
+	toolkit := NewToolkit(mock, DefaultConfig())
+	result, _, _ := toolkit.handleSearch(context.Background(), nil, SearchInput{Query: "test"})
+
+	if result.IsError {
+		t.Error("handleSearch() should not return error result")
+	}
+	if !acrossCalled {
+		t.Error("SearchAcrossEntities should have been called")
+	}
+}
+
 func TestSearchInputValidation(t *testing.T) {
 	mock := &mockClient{}
 	toolkit := NewToolkit(mock, DefaultConfig())
@@ -115,5 +206,109 @@ func TestSearchInputValidation(t *testing.T) {
 	result, _, _ := baseHandler(context.Background(), nil, "wrong type")
 	if !result.IsError {
 		t.Error("Should return error for invalid input type")
+	}
+}
+
+func TestResolveSearchTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input SearchInput
+		want  []string
+	}{
+		{
+			name:  "default to DATASET",
+			input: SearchInput{Query: "test"},
+			want:  []string{"DATASET"},
+		},
+		{
+			name:  "entity_type set",
+			input: SearchInput{Query: "test", EntityType: "DASHBOARD"},
+			want:  []string{"DASHBOARD"},
+		},
+		{
+			name:  "types overrides entity_type",
+			input: SearchInput{Query: "test", EntityType: "TAG", Types: []string{"DATASET", "DASHBOARD"}},
+			want:  []string{"DATASET", "DASHBOARD"},
+		},
+		{
+			name:  "types set without entity_type",
+			input: SearchInput{Query: "test", Types: []string{"DATA_PRODUCT"}},
+			want:  []string{"DATA_PRODUCT"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSearchTypes(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("resolveSearchTypes() = %v, want %v", got, tt.want)
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("resolveSearchTypes()[%d] = %q, want %q", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConvertFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		inputs  []SearchFilterInput
+		wantLen int
+	}{
+		{
+			name:    "empty filters",
+			inputs:  nil,
+			wantLen: 0,
+		},
+		{
+			name: "value promoted to values",
+			inputs: []SearchFilterInput{
+				{Field: "platform", Value: "urn:li:dataPlatform:trino"},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "values used directly",
+			inputs: []SearchFilterInput{
+				{Field: "fieldPaths", Values: []string{"email", "phone"}},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "with condition and negated",
+			inputs: []SearchFilterInput{
+				{Field: "tags", Values: []string{"urn:li:tag:deprecated"}, Condition: "EQUAL", Negated: true},
+			},
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertFilters(tt.inputs)
+			if len(got) != tt.wantLen {
+				t.Fatalf("convertFilters() len = %d, want %d", len(got), tt.wantLen)
+			}
+
+			// Verify value promotion
+			if tt.name == "value promoted to values" {
+				if len(got[0].Values) != 1 || got[0].Values[0] != "urn:li:dataPlatform:trino" {
+					t.Errorf("value not promoted: %v", got[0].Values)
+				}
+			}
+
+			// Verify condition/negated pass-through
+			if tt.name == "with condition and negated" {
+				if got[0].Condition != "EQUAL" {
+					t.Errorf("condition = %q, want EQUAL", got[0].Condition)
+				}
+				if !got[0].Negated {
+					t.Error("negated should be true")
+				}
+			}
+		})
 	}
 }

--- a/pkg/tools/structured_output_test.go
+++ b/pkg/tools/structured_output_test.go
@@ -293,7 +293,7 @@ func TestStructuredOutput_GetLineage_WithQueryProvider(t *testing.T) {
 
 func TestStructuredOutput_Search_NoQueryProvider(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Total:    1,
 				Entities: []types.SearchEntity{{URN: "urn:li:dataset:test"}},
@@ -313,7 +313,7 @@ func TestStructuredOutput_Search_NoQueryProvider(t *testing.T) {
 
 func TestStructuredOutput_Search_WithQueryProvider(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Total:    1,
 				Entities: []types.SearchEntity{{URN: "urn:li:dataset:test"}},
@@ -489,7 +489,7 @@ func TestResponseShape_GetLineage_WithQueryProvider(t *testing.T) {
 // provider returns search fields at the TOP LEVEL — not nested under a "result" wrapper key.
 func TestResponseShape_Search_WithQueryProvider(t *testing.T) {
 	mock := &mockClient{
-		searchFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{
 				Total:    1,
 				Entities: []types.SearchEntity{{URN: "urn:li:dataset:test", Name: "Test"}},

--- a/pkg/tools/toolkit_test.go
+++ b/pkg/tools/toolkit_test.go
@@ -16,6 +16,7 @@ import (
 // mockClient implements DataHubClient for testing.
 type mockClient struct {
 	searchFunc                            func(ctx context.Context, query string, opts ...client.SearchOption) (*types.SearchResult, error)
+	searchAcrossEntitiesFunc              func(ctx context.Context, query string, opts ...client.SearchOption) (*types.SearchResult, error)
 	getEntityFunc                         func(ctx context.Context, urn string) (*types.Entity, error)
 	getSchemaFunc                         func(ctx context.Context, urn string) (*types.SchemaMetadata, error)
 	getSchemasFunc                        func(ctx context.Context, urns []string) (map[string]*types.SchemaMetadata, error)
@@ -88,6 +89,13 @@ type mockClient struct {
 func (m *mockClient) Search(ctx context.Context, query string, opts ...client.SearchOption) (*types.SearchResult, error) {
 	if m.searchFunc != nil {
 		return m.searchFunc(ctx, query, opts...)
+	}
+	return &types.SearchResult{}, nil
+}
+
+func (m *mockClient) SearchAcrossEntities(ctx context.Context, query string, opts ...client.SearchOption) (*types.SearchResult, error) {
+	if m.searchAcrossEntitiesFunc != nil {
+		return m.searchAcrossEntitiesFunc(ctx, query, opts...)
 	}
 	return &types.SearchResult{}, nil
 }
@@ -1466,7 +1474,7 @@ func TestSearchModeRouting(t *testing.T) {
 			semanticCalled := false
 
 			mock := &mockClient{}
-			mock.searchFunc = func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			mock.searchAcrossEntitiesFunc = func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 				keywordCalled = true
 				return &types.SearchResult{}, nil
 			}


### PR DESCRIPTION
## Summary

Closes #129

- Upgrades `datahub_search` to use the `searchAcrossEntities` GraphQL query for both keyword and semantic modes, enabling advanced field-level filtering and multi-type search
- Adds `types` parameter (search across multiple entity types, overrides `entity_type`)
- Adds `filters` parameter with support for DataHub filter fields (`fieldPaths`, `fieldTags`, `fieldGlossaryTerms`, `fieldDescriptions`, `platform`, `domains`, `owners`, `tags`, `glossaryTerms`, `typeNames`)
- Full backward compatibility: existing `entity_type` and simple query usage unchanged
- New client API: `SearchFilter` type, `WithTypes()`/`WithSearchFilters()` options, `SearchAcrossEntities()` method
- `SemanticSearch` now also supports `WithTypes()` and `WithSearchFilters()`
- Shared `doSearchAcrossEntities` helper eliminates duplication between keyword and semantic code paths
- Single `SearchAcrossEntitiesQuery` GraphQL constant with full entity fragments (Dataset, Dashboard, DataFlow, DataProduct, GlossaryTerm, Tag, Document)
- Input validation rejects filters with empty `field` or missing `value`/`values`

## Test plan

- [x] `make verify` passes (lint, tests, coverage, security, schema-check, mutation, deadcode, build)
- [x] Existing search tests updated to use `SearchAcrossEntities` path
- [x] New tests for filter construction, type resolution, negation, GraphQL error handling
- [x] Backward compat: `entity_type` still works, defaults to DATASET when neither `types` nor `entity_type` set
- [x] Tests for `SemanticSearch` with types and filters (verifies fulltext flag preserved)
- [x] Tests for entityType fallback, types-overrides-entityType, no-types-searches-all
- [x] Tests for filter validation (empty field, missing values)
- [x] Tests for Value+Values merge and deduplication
- [ ] Manual test against a live DataHub instance with filter queries