### PR TITLE
fix: return empty entities array instead of null on zero search results

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -397,9 +397,10 @@ func (c *Client) Search(ctx context.Context, query string, opts ...SearchOption)
 	}
 
 	result := &types.SearchResult{
-		Total:  response.Search.Total,
-		Offset: response.Search.Start,
-		Limit:  response.Search.Count,
+		Entities: make([]types.SearchEntity, 0, len(response.Search.SearchResults)),
+		Total:    response.Search.Total,
+		Offset:   response.Search.Start,
+		Limit:    response.Search.Count,
 	}
 
 	for _, sr := range response.Search.SearchResults {

--- a/pkg/client/search_across.go
+++ b/pkg/client/search_across.go
@@ -186,9 +186,10 @@ func (c *Client) doSearchAcrossEntities(
 	}
 
 	result := &types.SearchResult{
-		Total:  response.SearchAcrossEntities.Total,
-		Offset: response.SearchAcrossEntities.Start,
-		Limit:  response.SearchAcrossEntities.Count,
+		Entities: make([]types.SearchEntity, 0, len(response.SearchAcrossEntities.SearchResults)),
+		Total:    response.SearchAcrossEntities.Total,
+		Offset:   response.SearchAcrossEntities.Start,
+		Limit:    response.SearchAcrossEntities.Count,
 	}
 
 	for _, sr := range response.SearchAcrossEntities.SearchResults {

--- a/pkg/client/search_across_test.go
+++ b/pkg/client/search_across_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -101,6 +102,49 @@ func TestSearchAcrossEntities(t *testing.T) {
 				t.Errorf("Entities count = %d, want %d", len(result.Entities), tt.wantCount)
 			}
 		})
+	}
+}
+
+func TestSearchAcrossEntities_ZeroResults_EntitiesNotNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"searchAcrossEntities": {
+					"start": 0, "count": 10, "total": 0, "searchResults": []
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     DefaultConfig(),
+		logger:     NopLogger{},
+	}
+
+	result, err := c.SearchAcrossEntities(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Entities == nil {
+		t.Fatal("Entities should be empty slice, not nil")
+	}
+	if len(result.Entities) != 0 {
+		t.Errorf("Entities count = %d, want 0", len(result.Entities))
+	}
+
+	// Verify JSON marshal produces [] not null
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(data), `"entities":null`) {
+		t.Error("JSON should contain empty array, not null")
 	}
 }
 

--- a/pkg/tools/search_test.go
+++ b/pkg/tools/search_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -202,6 +203,40 @@ func TestHandleSearch_KeywordUsesSearchAcrossEntities(t *testing.T) {
 	}
 	if !acrossCalled {
 		t.Error("SearchAcrossEntities should have been called")
+	}
+}
+
+func TestHandleSearch_ZeroResults_EntitiesIsEmptyArray(t *testing.T) {
+	mock := &mockClient{
+		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
+			return &types.SearchResult{
+				Entities: []types.SearchEntity{},
+				Total:    0,
+			}, nil
+		},
+	}
+
+	toolkit := NewToolkit(mock, DefaultConfig())
+	result, _, _ := toolkit.handleSearch(context.Background(), nil, SearchInput{Query: "nonexistent"})
+
+	if result.IsError {
+		t.Fatal("handleSearch() should not return error result")
+	}
+
+	// Extract JSON text and verify entities is [] not null
+	if len(result.Content) == 0 {
+		t.Fatal("no content in result")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+
+	if strings.Contains(tc.Text, `"entities": null`) {
+		t.Error("entities should be [] not null in JSON output")
+	}
+	if !strings.Contains(tc.Text, `"entities": []`) {
+		t.Error("expected empty entities array in JSON output")
 	}
 }
 

--- a/pkg/tools/search_test.go
+++ b/pkg/tools/search_test.go
@@ -207,6 +207,9 @@ func TestHandleSearch_KeywordUsesSearchAcrossEntities(t *testing.T) {
 }
 
 func TestHandleSearch_ZeroResults_EntitiesIsEmptyArray(t *testing.T) {
+	// Mock returns initialized empty slice (as the fixed client now does).
+	// The real nil→[] fix is tested at the client level in
+	// TestSearchAcrossEntities_ZeroResults_EntitiesNotNil.
 	mock := &mockClient{
 		searchAcrossEntitiesFunc: func(_ context.Context, _ string, _ ...client.SearchOption) (*types.SearchResult, error) {
 			return &types.SearchResult{


### PR DESCRIPTION
## Summary

Closes #131

When `datahub_search` returns zero results, the JSON response contained `"entities": null` instead of `"entities": []`, causing OutputSchema validation failures. The schema declares `entities` as `"type": "array"` which rejects null.

**Root cause:** Go's `json.Marshal` serializes nil slices as `null`. `SearchResult.Entities` was never initialized — it only got populated via `append` in a loop over results, so zero results left it nil.

**Fix:** Initialize `Entities` with `make([]SearchEntity, 0, len(results))` in both:
- `doSearchAcrossEntities` (used by keyword and semantic modes)
- `Search` (legacy client method)

## Test plan

- [x] `make verify` passes
- [x] New regression test asserts `"entities": []` not `null` in zero-result JSON output