### PR TITLE
feat(client): add SearchDocuments for document discovery (#164)

### DIFF
--- a/pkg/client/documents.go
+++ b/pkg/client/documents.go
@@ -7,14 +7,11 @@ import (
 	"github.com/txn2/mcp-datahub/pkg/types"
 )
 
-// GraphQL queries for context documents (DataHub 1.4.x+).
-const (
-	// GetDocumentQuery retrieves a single document by URN.
-	GetDocumentQuery = `
-query getDocument($urn: String!) {
-  document(urn: $urn) {
-    urn
-    type
+// documentSelectionFields is the shared GraphQL selection set for a Document
+// entity (everything after urn/type). Reused by GetDocumentQuery and
+// SearchDocumentsQuery so single-document reads and document search return
+// identical metadata from a single source of truth.
+const documentSelectionFields = `
     subType
     info {
       title
@@ -101,7 +98,16 @@ query getDocument($urn: String!) {
         }
       }
     }
-  }
+`
+
+// GraphQL queries for context documents (DataHub 1.4.x+).
+const (
+	// GetDocumentQuery retrieves a single document by URN.
+	GetDocumentQuery = `
+query getDocument($urn: String!) {
+  document(urn: $urn) {
+    urn
+    type` + documentSelectionFields + `  }
 }
 `
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -133,6 +133,9 @@ func WithDepth(depth int) LineageOption {
 // DefaultEntityType is the entity type used when none is specified.
 const DefaultEntityType = "DATASET"
 
+// EntityTypeDocument is the DataHub entity type for context documents.
+const EntityTypeDocument = "DOCUMENT"
+
 // Constants for lineage directions.
 const (
 	LineageDirectionUpstream   = "UPSTREAM"

--- a/pkg/client/schema_validation_test.go
+++ b/pkg/client/schema_validation_test.go
@@ -81,6 +81,9 @@ func TestGraphQLQueriesMatchSchema(t *testing.T) {
 		// Semantic search (semantic_search.go)
 		"SemanticSearchQuery": SemanticSearchQuery,
 
+		// Document search (search_documents.go)
+		"SearchDocumentsQuery": SearchDocumentsQuery,
+
 		// Tag/term/description mutations (write_graphql.go)
 		"AddTagMutation":            AddTagMutation,
 		"RemoveTagMutation":         RemoveTagMutation,

--- a/pkg/client/search_across.go
+++ b/pkg/client/search_across.go
@@ -136,32 +136,12 @@ func (c *Client) doSearchAcrossEntities(
 	extraFlags map[string]any,
 	opts []SearchOption,
 ) (*types.SearchResult, error) {
-	options := &searchOptions{
-		limit:  c.config.DefaultLimit,
-		offset: 0,
-	}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	if options.limit > c.config.MaxLimit {
-		options.limit = c.config.MaxLimit
-	}
-
-	input := map[string]any{
-		"query": query,
-		"start": options.offset,
-		"count": options.limit,
-	}
+	input, options := c.buildBaseSearchInput(query, opts)
 
 	if len(options.types) > 0 {
 		input["types"] = options.types
 	} else if options.entityType != "" {
 		input["types"] = []string{options.entityType}
-	}
-
-	if len(options.orFilters) > 0 {
-		input["orFilters"] = buildOrFilters(options.orFilters)
 	}
 
 	for k, v := range extraFlags {
@@ -197,6 +177,36 @@ func (c *Client) doSearchAcrossEntities(
 	}
 
 	return result, nil
+}
+
+// buildBaseSearchInput resolves SearchOptions and builds the shared
+// searchAcrossEntities input map (query, start, count, orFilters). Entity-type
+// scoping is left to the caller so each search method can apply its own types.
+// The resolved options are returned so callers can read type/entityType values.
+func (c *Client) buildBaseSearchInput(query string, opts []SearchOption) (map[string]any, *searchOptions) {
+	options := &searchOptions{
+		limit:  c.config.DefaultLimit,
+		offset: 0,
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.limit > c.config.MaxLimit {
+		options.limit = c.config.MaxLimit
+	}
+
+	input := map[string]any{
+		"query": query,
+		"start": options.offset,
+		"count": options.limit,
+	}
+
+	if len(options.orFilters) > 0 {
+		input["orFilters"] = buildOrFilters(options.orFilters)
+	}
+
+	return input, options
 }
 
 // buildOrFilters converts SearchFilter slices into the GraphQL orFilters structure.

--- a/pkg/client/search_documents.go
+++ b/pkg/client/search_documents.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/txn2/mcp-datahub/pkg/types"
+)
+
+// SearchDocumentsQuery searches context documents via searchAcrossEntities scoped
+// to the DOCUMENT entity type. Unlike the generic SearchAcrossEntitiesQuery, it
+// returns the full document selection set (the same fields as GetDocumentQuery)
+// so callers can discover and filter documents without a follow-up GetDocument
+// lookup. Available in DataHub 1.4.x+ (documents are a 1.4.x feature).
+const SearchDocumentsQuery = `
+query searchDocuments($input: SearchAcrossEntitiesInput!) {
+  searchAcrossEntities(input: $input) {
+    start
+    count
+    total
+    searchResults {
+      entity {
+        urn
+        type
+        ... on Document {` + documentSelectionFields + `        }
+      }
+    }
+  }
+}
+`
+
+// SearchDocuments searches context documents by relevance and returns full
+// document metadata. A query of "*" lists all documents; a text query ranks by
+// relevance. Use SearchOption values (WithLimit, WithOffset, WithSearchFilters)
+// to page or filter results.
+//
+// Unlike the point-lookup accessors (GetDocument, GetRelatedDocuments), this
+// method discovers documents without a known URN. Each result carries the same
+// metadata as GetDocument (URN, title, sub-type, related-asset URNs,
+// showInGlobalContext, ownership, tags, glossary terms, and domain) so callers
+// can filter to globally-visible documents.
+//
+// Available in DataHub 1.4.x+.
+func (c *Client) SearchDocuments(ctx context.Context, query string, opts ...SearchOption) ([]types.Document, error) {
+	input, _ := c.buildBaseSearchInput(query, opts)
+	input["types"] = []string{EntityTypeDocument}
+
+	variables := map[string]any{
+		"input": input,
+	}
+
+	var response struct {
+		SearchAcrossEntities struct {
+			SearchResults []struct {
+				Entity documentResponse `json:"entity"`
+			} `json:"searchResults"`
+		} `json:"searchAcrossEntities"`
+	}
+
+	if err := c.Execute(ctx, SearchDocumentsQuery, variables, &response); err != nil {
+		return nil, fmt.Errorf("SearchDocuments(%q): %w", query, err)
+	}
+
+	docs := make([]types.Document, 0, len(response.SearchAcrossEntities.SearchResults))
+	for i := range response.SearchAcrossEntities.SearchResults {
+		docs = append(docs, *parseDocumentResponse(&response.SearchAcrossEntities.SearchResults[i].Entity))
+	}
+
+	return docs, nil
+}

--- a/pkg/client/search_documents_test.go
+++ b/pkg/client/search_documents_test.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchDocuments(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		query     string
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:  "documents found",
+			query: "incident runbook",
+			response: `{"data": {"searchAcrossEntities": {
+				"start": 0,
+				"count": 10,
+				"total": 2,
+				"searchResults": [
+					{"entity": {
+						"urn": "urn:li:document:runbook-1",
+						"type": "DOCUMENT",
+						"subType": "RUNBOOK",
+						"info": {
+							"title": "Incident Runbook",
+							"contents": {"text": "Step 1: Check logs"},
+							"status": {"state": "PUBLISHED"},
+							"relatedAssets": [{"asset": {"urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)"}}]
+						},
+						"settings": {"showInGlobalContext": true}
+					}},
+					{"entity": {
+						"urn": "urn:li:document:faq-1",
+						"type": "DOCUMENT",
+						"subType": "FAQ",
+						"info": {
+							"title": "Onboarding FAQ",
+							"contents": {"text": "Frequently asked questions"},
+							"status": {"state": "PUBLISHED"}
+						},
+						"settings": {"showInGlobalContext": false}
+					}}
+				]
+			}}}`,
+			wantCount: 2,
+		},
+		{
+			name:  "list all with wildcard",
+			query: "*",
+			response: `{"data": {"searchAcrossEntities": {
+				"start": 0,
+				"count": 10,
+				"total": 0,
+				"searchResults": []
+			}}}`,
+			wantCount: 0,
+		},
+		{
+			name:     "graphql error",
+			query:    "test",
+			response: `{"errors": [{"message": "search failed"}]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify the request scopes the search to the DOCUMENT entity type.
+				body, _ := io.ReadAll(r.Body)
+				var req struct {
+					Variables struct {
+						Input struct {
+							Query string   `json:"query"`
+							Types []string `json:"types"`
+						} `json:"input"`
+					} `json:"variables"`
+				}
+				_ = json.Unmarshal(body, &req)
+				if len(req.Variables.Input.Types) != 1 || req.Variables.Input.Types[0] != "DOCUMENT" {
+					t.Errorf("input.types = %v, want [DOCUMENT]", req.Variables.Input.Types)
+				}
+				if req.Variables.Input.Query != tt.query {
+					t.Errorf("input.query = %q, want %q", req.Variables.Input.Query, tt.query)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := &Client{
+				endpoint:   server.URL,
+				token:      "test-token",
+				httpClient: server.Client(),
+				logger:     NopLogger{},
+				config:     DefaultConfig(),
+			}
+
+			docs, err := c.SearchDocuments(context.Background(), tt.query)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(docs) != tt.wantCount {
+				t.Fatalf("docs len = %d, want %d", len(docs), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestSearchDocuments_ResultFields(t *testing.T) {
+	response := `{"data": {"searchAcrossEntities": {
+		"start": 0,
+		"count": 10,
+		"total": 1,
+		"searchResults": [
+			{"entity": {
+				"urn": "urn:li:document:runbook-1",
+				"type": "DOCUMENT",
+				"subType": "RUNBOOK",
+				"info": {
+					"title": "Incident Runbook",
+					"contents": {"text": "Step 1: Check logs"},
+					"status": {"state": "PUBLISHED"},
+					"relatedAssets": [
+						{"asset": {"urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)"}},
+						{"asset": {"urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.orders,PROD)"}}
+					]
+				},
+				"settings": {"showInGlobalContext": true},
+				"ownership": {"owners": [{"owner": {"urn": "urn:li:corpuser:alice", "username": "alice"}, "type": "DATAOWNER"}]},
+				"tags": {"tags": [{"tag": {"urn": "urn:li:tag:Production", "name": "Production"}}]},
+				"glossaryTerms": {"terms": [{"term": {"urn": "urn:li:glossaryTerm:pii", "properties": {"name": "PII"}}}]},
+				"domain": {"domain": {"urn": "urn:li:domain:eng", "properties": {"name": "Engineering"}}}
+			}}
+		]
+	}}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+		config:     DefaultConfig(),
+	}
+
+	docs, err := c.SearchDocuments(context.Background(), "runbook")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("docs len = %d, want 1", len(docs))
+	}
+
+	doc := docs[0]
+	if doc.URN != "urn:li:document:runbook-1" {
+		t.Errorf("URN = %q, want urn:li:document:runbook-1", doc.URN)
+	}
+	if doc.Title != "Incident Runbook" {
+		t.Errorf("Title = %q, want Incident Runbook", doc.Title)
+	}
+	if doc.SubType != "RUNBOOK" {
+		t.Errorf("SubType = %q, want RUNBOOK", doc.SubType)
+	}
+	if doc.Settings == nil || !doc.Settings.ShowInGlobalContext {
+		t.Errorf("Settings = %+v, want ShowInGlobalContext=true", doc.Settings)
+	}
+	if len(doc.RelatedAssets) != 2 {
+		t.Fatalf("RelatedAssets len = %d, want 2", len(doc.RelatedAssets))
+	}
+	if doc.RelatedAssets[0].URN != "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)" {
+		t.Errorf("RelatedAssets[0].URN = %q", doc.RelatedAssets[0].URN)
+	}
+
+	// Governance metadata must survive document search (not just point lookups),
+	// matching the fields returned by GetDocument.
+	if len(doc.Owners) != 1 || doc.Owners[0].Name != "alice" {
+		t.Errorf("Owners = %+v, want alice", doc.Owners)
+	}
+	if len(doc.Tags) != 1 || doc.Tags[0].Name != "Production" {
+		t.Errorf("Tags = %+v, want Production", doc.Tags)
+	}
+	if len(doc.GlossaryTerms) != 1 || doc.GlossaryTerms[0].Name != "PII" {
+		t.Errorf("GlossaryTerms = %+v, want PII", doc.GlossaryTerms)
+	}
+	if doc.Domain == nil || doc.Domain.Name != "Engineering" {
+		t.Errorf("Domain = %+v, want Engineering", doc.Domain)
+	}
+}
+
+func TestSearchDocuments_LimitCapping(t *testing.T) {
+	var gotCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Variables struct {
+				Input struct {
+					Count int `json:"count"`
+				} `json:"input"`
+			} `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &req)
+		gotCount = req.Variables.Input.Count
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": {"searchAcrossEntities": {"start": 0, "count": 0, "total": 0, "searchResults": []}}}`))
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig()
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+		config:     cfg,
+	}
+
+	if _, err := c.SearchDocuments(context.Background(), "*", WithLimit(cfg.MaxLimit+100)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCount != cfg.MaxLimit {
+		t.Errorf("count = %d, want capped to MaxLimit %d", gotCount, cfg.MaxLimit)
+	}
+}

--- a/pkg/client/search_helpers.go
+++ b/pkg/client/search_helpers.go
@@ -76,7 +76,7 @@ func parseSearchResult(sr searchResultItem) types.SearchEntity {
 	// For Document the title comes from info, content serves as description.
 	// Guard behind type check to avoid mis-attributing info fields from
 	// non-document entities in the polymorphic GraphQL union response.
-	if sr.Entity.Type == "DOCUMENT" {
+	if sr.Entity.Type == EntityTypeDocument {
 		if sr.Entity.Info.Title != "" {
 			name = sr.Entity.Info.Title
 		}


### PR DESCRIPTION
## Summary

Adds **`Client.SearchDocuments(ctx, query string, opts ...SearchOption) ([]types.Document, error)`** so callers can **discover** DataHub context documents by relevance — without already knowing a URN.

Closes #164.

Every existing document accessor is a point lookup (`GetDocument(urn)`, `GetRelatedDocuments(urn)`, `GetContextDocuments(urn)`): you must already know the document's URN, or an entity URN it's related to. Nothing answered *"what documents exist?"* or *"find documents about X."* This stranded context-document knowledge — a downstream consumer could read a document only if it already had the URN.

`SearchDocuments` runs DataHub's `searchAcrossEntities` GraphQL scoped to the `DOCUMENT` entity type:

- `query = "*"` lists all documents; a text query ranks by relevance.
- Reuses the existing `SearchOption`s (`WithLimit`, `WithOffset`, `WithSearchFilters`) and caps to `MaxLimit`.
- Each result carries the **same metadata as `GetDocument`**: URN, title, sub-type, related-asset URNs, `showInGlobalContext`, ownership, tags, glossary terms, and domain — so a consumer can filter to globally-visible documents or surface the rest for a backfill.

## Why a library method, not a new MCP tool

This is intentionally a **client-library** capability, not a new MCP tool (consistent with the keep-tool-count-lean design principle). It unblocks **txn2/mcp-data-platform#692**: with document search available upstream, the platform can add a DataHub-documents **search _source_** to its unified `search`, making context-document knowledge discoverable and migratable into knowledge pages. Without this upstream method, that downstream work cannot be built.

## Naming note (grounded in the schema)

DataHub's GraphQL entity type is `Document` / `EntityType.DOCUMENT` (`entity.graphql`, `documents.graphql`); "context document" is the feature/UX name and this repo's write-wrapper name (`UpsertContextDocument`). A search scoped by entity type must use the `DOCUMENT` enum — the same value `search_helpers.go` already branches on. The method follows the schema-level naming of the other document read methods (`GetDocument`, `GetRelatedDocuments`).

## Implementation

- **New** `pkg/client/search_documents.go` — `SearchDocuments` + `SearchDocumentsQuery`.
- **Shared GraphQL fragment** — extracted `documentSelectionFields` and built both `GetDocumentQuery` and `SearchDocumentsQuery` from it, so single-document reads and document search return identical metadata from one source of truth (no field drift).
- **Shared input helper** — extracted `Client.buildBaseSearchInput(query, opts)` for the common query/start/count/orFilters + limit-capping logic, now used by both `doSearchAcrossEntities` and `SearchDocuments`.
- **`EntityTypeDocument`** constant added in `options.go`; `search_helpers.go` updated to use it.
- **Schema validation** — registered `SearchDocumentsQuery` in `schema_validation_test.go` so `make schema-check` validates it against the pinned upstream DataHub schema (v1.5.0.1).

## Testing

New `pkg/client/search_documents_test.go` — GraphQL httptest mock tests in the `documents_test.go` style:

- Request is correctly scoped to the `DOCUMENT` entity type and passes the query through.
- Result fields parse correctly — URN, title, sub-type, multiple related-asset URNs, `showInGlobalContext`, **and governance metadata** (ownership, tags, glossary terms, domain).
- Wildcard (`*`) listing and empty-result handling.
- `WithLimit` is capped to `MaxLimit`.
- GraphQL error propagation.

`make verify` passes locally (lint, race tests, coverage, patch-coverage, security, schema-check, mutation, deadcode, build-check). The `deadcode` `unreachable func` lines are the known non-blocking exported-library-API entries.

## Acceptance criteria

- [x] Search documents by text and list all via `*`, receiving document URNs + metadata **without** a known URN.
- [x] Implemented via `searchAcrossEntities` scoped to `DOCUMENT`, reusing existing search options.
- [x] `showInGlobalContext` available on each result.
- [x] Covered by a GraphQL httptest mock test in the style of `documents_test.go`.
