### PR TITLE
fix(client): return full document projection from GetRelatedDocuments (#166)

### DIFF
--- a/pkg/client/documents.go
+++ b/pkg/client/documents.go
@@ -124,72 +124,28 @@ query getRelatedDocuments($urn: String!, $input: RelatedDocumentsInput!) {
       relatedDocuments(input: $input) {
         total
         documents {
-          urn
-          subType
-          info {
-            title
-            contents {
-              text
-            }
-            status {
-              state
-            }
-          }
-        }
+          urn` + documentSelectionFields + `        }
       }
     }
     ... on GlossaryTerm {
       relatedDocuments(input: $input) {
         total
         documents {
-          urn
-          subType
-          info {
-            title
-            contents {
-              text
-            }
-            status {
-              state
-            }
-          }
-        }
+          urn` + documentSelectionFields + `        }
       }
     }
     ... on GlossaryNode {
       relatedDocuments(input: $input) {
         total
         documents {
-          urn
-          subType
-          info {
-            title
-            contents {
-              text
-            }
-            status {
-              state
-            }
-          }
-        }
+          urn` + documentSelectionFields + `        }
       }
     }
     ... on Container {
       relatedDocuments(input: $input) {
         total
         documents {
-          urn
-          subType
-          info {
-            title
-            contents {
-              text
-            }
-            status {
-              state
-            }
-          }
-        }
+          urn` + documentSelectionFields + `        }
       }
     }
   }

--- a/pkg/client/documents_test.go
+++ b/pkg/client/documents_test.go
@@ -178,6 +178,65 @@ func TestGetRelatedDocuments(t *testing.T) {
 	}
 }
 
+// TestGetRelatedDocuments_FullProjection guards that related documents carry the
+// same projection as GetDocument/SearchDocuments — specifically settings and
+// relatedAssets. Without settings, a hidden document (showInGlobalContext=false)
+// parses as Settings==nil and a visibility-gated consumer would surface it.
+func TestGetRelatedDocuments_FullProjection(t *testing.T) {
+	response := `{"data": {"entity": {"relatedDocuments": {
+		"total": 1,
+		"documents": [
+			{
+				"urn": "urn:li:document:hidden-1",
+				"subType": "RUNBOOK",
+				"info": {
+					"title": "Hidden Runbook",
+					"contents": {"text": "internal only"},
+					"status": {"state": "PUBLISHED"},
+					"relatedAssets": [{"asset": {"urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)"}}]
+				},
+				"settings": {"showInGlobalContext": false}
+			}
+		]
+	}}}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+		config:     DefaultConfig(),
+	}
+
+	docs, err := c.GetRelatedDocuments(context.Background(), "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("len = %d, want 1", len(docs))
+	}
+
+	doc := docs[0]
+	if doc.Settings == nil {
+		t.Fatal("Settings == nil; visibility flag did not travel on the related-documents path")
+	}
+	if doc.Settings.ShowInGlobalContext {
+		t.Errorf("ShowInGlobalContext = true, want false (steward hid this document)")
+	}
+	if len(doc.RelatedAssets) != 1 {
+		t.Fatalf("RelatedAssets len = %d, want 1", len(doc.RelatedAssets))
+	}
+	if doc.RelatedAssets[0].URN != "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)" {
+		t.Errorf("RelatedAssets[0].URN = %q", doc.RelatedAssets[0].URN)
+	}
+}
+
 func TestParseDocumentResponse(t *testing.T) {
 	raw := `{
 		"urn": "urn:li:document:test",


### PR DESCRIPTION
## Summary

Fixes #166. `GetRelatedDocuments` returned a **thinner projection** than `GetDocument` / `SearchDocuments`: related documents came back without `settings{showInGlobalContext}` and without `relatedAssets`, because `GetRelatedDocumentsQuery` requested a hand-written subset in each per-entity `... on Document` block instead of the shared `documentSelectionFields` fragment introduced in #165.

The parse struct (`relatedDocumentsResult` → `documentResponse`) and the mapping already supported both fields — only the GraphQL query was missing them — so every related document parsed with `Settings == nil` and `RelatedAssets` empty.

## The bug (visibility leak)

A steward sets `showInGlobalContext = false` to keep a context document out of global search. A caller doing an entity-keyed lookup (`GetRelatedDocuments` for a dataset the hidden document links to) received that document with `Settings == nil`. Because DataHub's documented default for `global_context` is `true`, a correct consumer treats absent settings as **visible** — and therefore surfaces a document the steward explicitly hid, since the hide flag never traveled on this path. The same document fetched via `GetDocument` / `SearchDocuments` carried the flag and was correctly suppressed, so a document leaked through **one path only**.

`GetRelatedDocuments` was therefore not at parity with the other document accessors and could not back a visibility-gated, entity-keyed document search.

## Fix

Reuse the shared `documentSelectionFields` fragment in each of the four per-entity `relatedDocuments { ... documents { ... } }` blocks (Dataset, GlossaryTerm, GlossaryNode, Container), replacing the hand-written `urn / subType / title / contents / status` subset. Related documents now carry the **identical projection** to `GetDocument` / `SearchDocuments`: `settings`, `relatedAssets`, `status`, `subType`, owners, tags, glossary terms, and domain. The existing `relatedDocumentsResult` mapping already populates these.

This also removes the per-block duplication (~48 fewer lines in `documents.go`); the four blocks now share one source of truth, so the projection can no longer drift between document accessors.

## Testing

- New `TestGetRelatedDocuments_FullProjection`: a related document returned with `showInGlobalContext: false` and a `relatedAssets` entry now parses with `Settings.ShowInGlobalContext == false` and the related-asset URN populated — the exact leak, now guarded by a regression test.
- `GetRelatedDocumentsQuery` remains registered in `schema_validation_test.go`, so the expanded selection is validated against the pinned upstream DataHub schema (v1.5.0.1) by `make schema-check`.
- `make verify` passes locally (lint, race tests, coverage, patch-coverage, security, schema-check, mutation, deadcode, build-check).

## Acceptance criteria

- [x] `GetRelatedDocuments` results carry `settings.showInGlobalContext` and `relatedAssets`, identical to `GetDocument` / `SearchDocuments`.
- [x] A GraphQL httptest-mock test asserts a related document with `showInGlobalContext: false` and a `relatedAssets` entry parses with `Settings.ShowInGlobalContext == false` and the related-asset URN populated.

## Downstream motivation

Unblocks the **entity-keyed arm** of txn2/mcp-data-platform#692 (context documents discoverable by the entity they document, for parity with the knowledge-pages provider). Without `settings` in this projection, that arm cannot gate visibility and would leak hidden documents.

## Note

This is a follow-up to #165: that PR added `documentSelectionFields` and wired it into `GetDocument` and `SearchDocuments` but left `GetRelatedDocuments` on its old thin subset, which is the root cause here. This change brings the third accessor to parity.
