### PR TITLE
fix(client): read tags/terms for GraphQL-only entity types (#168)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -578,7 +578,104 @@ func (c *Client) GetEntity(ctx context.Context, urn string) (*types.Entity, erro
 		}
 	}
 
+	// Supplement tags/glossary terms for GraphQL-only entity types via a separate
+	// raw-aspect read. Degrades gracefully so it never fails the GetEntity call.
+	c.enrichRawAspectAssociations(ctx, entity)
+
 	return entity, nil
+}
+
+// rawAspectReadTypes are entity types whose globalTags/glossaryTerms associations
+// are not exposed as typed GraphQL fields and so must be read from raw aspects.
+var rawAspectReadTypes = map[string]bool{
+	entityTypeDomain:       true,
+	entityTypeGlossaryTerm: true,
+	entityTypeGlossaryNode: true,
+}
+
+// enrichRawAspectAssociations populates an entity's Tags and GlossaryTerms for
+// GraphQL-only entity types (domain, glossaryTerm, glossaryNode) by reading the
+// globalTags/glossaryTerms raw aspects in a separate query. DataHub does not
+// expose typed tags/glossaryTerms GraphQL fields for these types. The read
+// degrades gracefully: any failure (unsupported on older DataHub, unauthorized
+// token) leaves the associations untouched and logs at debug level, preserving
+// the prior GetEntity behavior of returning the entity rather than erroring.
+func (c *Client) enrichRawAspectAssociations(ctx context.Context, entity *types.Entity) {
+	entityType, err := entityTypeFromURN(entity.URN)
+	if err != nil || !rawAspectReadTypes[entityType] {
+		return
+	}
+
+	var response struct {
+		Entity struct {
+			Aspects []rawAspect `json:"aspects"`
+		} `json:"entity"`
+	}
+
+	if err := c.Execute(ctx, GetEntityAspectsQuery, map[string]any{"urn": entity.URN}, &response); err != nil {
+		c.logger.Debug("GetEntity raw-aspect association fallback", "urn", entity.URN, "error", err.Error())
+		return
+	}
+
+	applyRawAspects(entity, response.Entity.Aspects)
+}
+
+// rawAspect mirrors the GraphQL RawAspect type. It carries an aspect's name and
+// its serialized JSON payload, used to read aspects that are not exposed as
+// typed GraphQL fields on an entity (e.g. globalTags/glossaryTerms on domain,
+// glossaryTerm, and glossaryNode).
+type rawAspect struct {
+	AspectName string `json:"aspectName"`
+	Payload    string `json:"payload"`
+}
+
+// applyRawAspects populates an entity's Tags and GlossaryTerms from raw aspect
+// payloads. Typed values parsed from dedicated GraphQL fields take precedence
+// and are never overwritten. URN is the only field available from raw aspects.
+func applyRawAspects(entity *types.Entity, aspects []rawAspect) {
+	for _, a := range aspects {
+		switch a.AspectName {
+		case "globalTags":
+			applyRawGlobalTags(entity, a.Payload)
+		case "glossaryTerms":
+			applyRawGlossaryTerms(entity, a.Payload)
+		}
+	}
+}
+
+// applyRawGlobalTags parses a globalTags aspect payload and appends its tag URNs
+// to the entity. A malformed payload or already-populated tags is a no-op.
+func applyRawGlobalTags(entity *types.Entity, payload string) {
+	if len(entity.Tags) > 0 {
+		return
+	}
+	var ga globalTagsAspect
+	if err := json.Unmarshal([]byte(payload), &ga); err != nil {
+		return
+	}
+	for _, t := range ga.Tags {
+		if t.Tag != "" {
+			entity.Tags = append(entity.Tags, types.Tag{URN: t.Tag})
+		}
+	}
+}
+
+// applyRawGlossaryTerms parses a glossaryTerms aspect payload and appends its
+// term URNs to the entity. A malformed payload or already-populated terms is a
+// no-op.
+func applyRawGlossaryTerms(entity *types.Entity, payload string) {
+	if len(entity.GlossaryTerms) > 0 {
+		return
+	}
+	var gt glossaryTermsAspect
+	if err := json.Unmarshal([]byte(payload), &gt); err != nil {
+		return
+	}
+	for _, term := range gt.Terms {
+		if term.URN != "" {
+			entity.GlossaryTerms = append(entity.GlossaryTerms, types.GlossaryTerm{URN: term.URN})
+		}
+	}
 }
 
 // GetSchema retrieves schema metadata for a dataset.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -525,6 +525,174 @@ func TestClientGetEntityWithEditableProperties(t *testing.T) {
 	}
 }
 
+func TestClientGetEntityRawAspectsTagsTerms(t *testing.T) {
+	// Domain/glossaryTerm/glossaryNode do not expose typed tags/glossaryTerms
+	// GraphQL fields; GetEntity reads them from raw aspect payloads instead.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]interface{}{
+			"data": map[string]interface{}{
+				"entity": map[string]interface{}{
+					"urn":  "urn:li:domain:marketing",
+					"type": "DOMAIN",
+					"aspects": []map[string]interface{}{
+						{
+							"aspectName": "globalTags",
+							"payload":    `{"tags":[{"tag":"urn:li:tag:Curated"},{"tag":"urn:li:tag:PII"}]}`,
+						},
+						{
+							"aspectName": "glossaryTerms",
+							"payload":    `{"terms":[{"urn":"urn:li:glossaryTerm:Revenue"}],"auditStamp":{"time":0,"actor":"urn:li:corpuser:datahub"}}`,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{URL: server.URL, Token: "test-token", RetryMax: 0})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	entity, err := client.GetEntity(context.Background(), "urn:li:domain:marketing")
+	if err != nil {
+		t.Fatalf("GetEntity() unexpected error: %v", err)
+	}
+
+	wantTags := []string{"urn:li:tag:Curated", "urn:li:tag:PII"}
+	if len(entity.Tags) != len(wantTags) {
+		t.Fatalf("GetEntity() Tags len = %d, want %d", len(entity.Tags), len(wantTags))
+	}
+	for i, want := range wantTags {
+		if entity.Tags[i].URN != want {
+			t.Errorf("GetEntity() Tags[%d].URN = %q, want %q", i, entity.Tags[i].URN, want)
+		}
+	}
+
+	if len(entity.GlossaryTerms) != 1 {
+		t.Fatalf("GetEntity() GlossaryTerms len = %d, want 1", len(entity.GlossaryTerms))
+	}
+	if got := entity.GlossaryTerms[0].URN; got != "urn:li:glossaryTerm:Revenue" {
+		t.Errorf("GetEntity() GlossaryTerms[0].URN = %q, want urn:li:glossaryTerm:Revenue", got)
+	}
+}
+
+func TestClientGetEntityRawAspectsGracefulDegradation(t *testing.T) {
+	// When the raw-aspect read fails (e.g. unsupported on older DataHub or an
+	// unauthorized token), GetEntity must still return the entity with empty
+	// tags/terms rather than failing the whole call.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "getEntityAspects") {
+			writeJSON(t, w, map[string]interface{}{
+				"errors": []map[string]interface{}{
+					{"message": "Unauthorized to read aspects"},
+				},
+			})
+			return
+		}
+		writeJSON(t, w, map[string]interface{}{
+			"data": map[string]interface{}{
+				"entity": map[string]interface{}{
+					"urn":  "urn:li:domain:marketing",
+					"type": "DOMAIN",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{URL: server.URL, Token: "test-token", RetryMax: 0})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	entity, err := client.GetEntity(context.Background(), "urn:li:domain:marketing")
+	if err != nil {
+		t.Fatalf("GetEntity() should degrade gracefully, got error: %v", err)
+	}
+	if entity.URN != "urn:li:domain:marketing" {
+		t.Errorf("GetEntity() URN = %q, want urn:li:domain:marketing", entity.URN)
+	}
+	if len(entity.Tags) != 0 || len(entity.GlossaryTerms) != 0 {
+		t.Errorf("GetEntity() expected empty tags/terms on degraded read, got %d tags, %d terms", len(entity.Tags), len(entity.GlossaryTerms))
+	}
+}
+
+func TestApplyRawAspects(t *testing.T) {
+	tests := []struct {
+		name      string
+		entity    *types.Entity
+		aspects   []rawAspect
+		wantTags  []string
+		wantTerms []string
+	}{
+		{
+			name:   "populates tags and terms from payloads",
+			entity: &types.Entity{},
+			aspects: []rawAspect{
+				{AspectName: "globalTags", Payload: `{"tags":[{"tag":"urn:li:tag:A"}]}`},
+				{AspectName: "glossaryTerms", Payload: `{"terms":[{"urn":"urn:li:glossaryTerm:B"}]}`},
+			},
+			wantTags:  []string{"urn:li:tag:A"},
+			wantTerms: []string{"urn:li:glossaryTerm:B"},
+		},
+		{
+			name:      "typed values take precedence and are not overwritten",
+			entity:    &types.Entity{Tags: []types.Tag{{URN: "urn:li:tag:Existing", Name: "Existing"}}},
+			aspects:   []rawAspect{{AspectName: "globalTags", Payload: `{"tags":[{"tag":"urn:li:tag:Raw"}]}`}},
+			wantTags:  []string{"urn:li:tag:Existing"},
+			wantTerms: nil,
+		},
+		{
+			name:      "malformed payload is a no-op",
+			entity:    &types.Entity{},
+			aspects:   []rawAspect{{AspectName: "globalTags", Payload: `not-json`}, {AspectName: "glossaryTerms", Payload: ``}},
+			wantTags:  nil,
+			wantTerms: nil,
+		},
+		{
+			name:      "empty urns are skipped",
+			entity:    &types.Entity{},
+			aspects:   []rawAspect{{AspectName: "globalTags", Payload: `{"tags":[{"tag":""},{"tag":"urn:li:tag:Keep"}]}`}},
+			wantTags:  []string{"urn:li:tag:Keep"},
+			wantTerms: nil,
+		},
+		{
+			name:      "unknown aspect names ignored",
+			entity:    &types.Entity{},
+			aspects:   []rawAspect{{AspectName: "ownership", Payload: `{"owners":[]}`}},
+			wantTags:  nil,
+			wantTerms: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyRawAspects(tt.entity, tt.aspects)
+
+			if len(tt.entity.Tags) != len(tt.wantTags) {
+				t.Fatalf("Tags len = %d, want %d", len(tt.entity.Tags), len(tt.wantTags))
+			}
+			for i, want := range tt.wantTags {
+				if tt.entity.Tags[i].URN != want {
+					t.Errorf("Tags[%d].URN = %q, want %q", i, tt.entity.Tags[i].URN, want)
+				}
+			}
+
+			if len(tt.entity.GlossaryTerms) != len(tt.wantTerms) {
+				t.Fatalf("GlossaryTerms len = %d, want %d", len(tt.entity.GlossaryTerms), len(tt.wantTerms))
+			}
+			for i, want := range tt.wantTerms {
+				if tt.entity.GlossaryTerms[i].URN != want {
+					t.Errorf("GlossaryTerms[%d].URN = %q, want %q", i, tt.entity.GlossaryTerms[i].URN, want)
+				}
+			}
+		})
+	}
+}
+
 func TestClientGetEntityWithPropertiesAndDeprecation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(t, w, map[string]interface{}{

--- a/pkg/client/queries.go
+++ b/pkg/client/queries.go
@@ -220,6 +220,37 @@ query getEntity($urn: String!) {
 }
 `
 
+	// GetEntityAspectsQuery reads the globalTags and glossaryTerms raw aspects of
+	// GraphQL-only entity types (domain, glossaryTerm, glossaryNode). These types
+	// do not expose typed tags/glossaryTerms GraphQL fields, so their associations
+	// are read through the experimental aspects API instead. This is a separate
+	// query from GetEntityQuery so a failure (older DataHub, unauthorized token)
+	// degrades gracefully rather than failing the whole GetEntity call.
+	GetEntityAspectsQuery = `
+query getEntityAspects($urn: String!) {
+  entity(urn: $urn) {
+    ... on Domain {
+      aspects(input: { aspectNames: ["globalTags", "glossaryTerms"] }) {
+        aspectName
+        payload
+      }
+    }
+    ... on GlossaryTerm {
+      aspects(input: { aspectNames: ["globalTags", "glossaryTerms"] }) {
+        aspectName
+        payload
+      }
+    }
+    ... on GlossaryNode {
+      aspects(input: { aspectNames: ["globalTags", "glossaryTerms"] }) {
+        aspectName
+        payload
+      }
+    }
+  }
+}
+`
+
 	// GetSchemaQuery retrieves schema for a dataset.
 	GetSchemaQuery = `
 query getSchema($urn: String!) {

--- a/pkg/client/schema_validation_test.go
+++ b/pkg/client/schema_validation_test.go
@@ -30,6 +30,7 @@ func TestGraphQLQueriesMatchSchema(t *testing.T) {
 		// Core queries (queries.go)
 		"SearchQuery":                 SearchQuery,
 		"GetEntityQuery":              GetEntityQuery,
+		"GetEntityAspectsQuery":       GetEntityAspectsQuery,
 		"GetSchemaQuery":              GetSchemaQuery,
 		"GetLineageQuery":             GetLineageQuery,
 		"GetQueriesQuery":             GetQueriesQuery,


### PR DESCRIPTION
## Summary

Closes #168.

`domain`, `glossaryTerm`, and `glossaryNode` can have tags and glossary terms **written** via the `addTag`/`removeTag`/`addTerm`/`removeTerm` GraphQL mutations, but their associations could not be **read** back:

- These three types do **not** expose typed `tags: GlobalTags` / `glossaryTerms: GlossaryTerms` GraphQL fields (verified against the upstream schema, `testdata/datahub-schema/entity.graphql` @ v1.5.0.1).
- The REST aspect API does not register `globalTags` / `glossaryTerms` for them (which is why writes already route through GraphQL).
- `GetEntityQuery` only had typed inline fragments for `Dataset` and `Dashboard`, so `GetEntity` returned empty `Tags`/`GlossaryTerms` for every other type.

Net: a caller could add a tag/term to these entities but could not read the resulting set — breaking post-write verification and rollback before-images for downstream consumers (e.g. `txn2/mcp-data-platform`).

## What changed

`GetEntity` now populates `Tags`/`GlossaryTerms` for `domain`/`glossaryTerm`/`glossaryNode` by reading the `globalTags` and `glossaryTerms` **raw aspects** through DataHub's experimental `aspects(input:)` API — the only GraphQL read path these types expose for this data.

| File | Change |
|------|--------|
| `pkg/client/queries.go` | New `GetEntityAspectsQuery` with `... on Domain/GlossaryTerm/GlossaryNode { aspects(input: { aspectNames: ["globalTags","glossaryTerms"] }) { aspectName payload } }` |
| `pkg/client/client.go` | New `rawAspect` type, `applyRawAspects` (+ `applyRawGlobalTags`/`applyRawGlossaryTerms` helpers), and `enrichRawAspectAssociations` invoked from `GetEntity` for the three types |
| `pkg/client/client_test.go` | End-to-end raw-aspect test, graceful-degradation test, table-driven `TestApplyRawAspects` |
| `pkg/client/schema_validation_test.go` | Registers `GetEntityAspectsQuery` for schema validation |

### Design notes

- **Approach vs. the issue.** The issue proposed Option 1 (typed `... on Domain { tags { ... } }`). That is **not viable** — those typed fields don't exist on these types. The raw-aspects read achieves the same outcome (Option 1's intent) and reuses the exact `globalTagsAspect`/`glossaryTermsAspect` structs the write path already serializes, so payload shapes are guaranteed consistent.
- **Graceful degradation.** The aspect read is a **separate query**, not folded into `GetEntityQuery`. `parseGraphQLResponse` fails hard on any `errors` entry, so embedding it would make `GetEntity` fail entirely on older DataHub or with an unauthorized token. As a separate best-effort call it logs a debug "graceful fallback" and returns the entity intact — matching the established `GetIncidents`/`GetStructuredProperties` pattern.
- **No new tools / no new public API.** Existing `GetEntity` (and the `datahub_get_entity` tool) simply return more data for these types.

### Known limitation

Raw aspect payloads carry only **URNs**, so `Name`/`Description` are left empty for tags/terms on these three types (typed values from `Dataset`/`Dashboard` are unaffected and still include names). URNs are sufficient for the downstream verification and rollback-before-image use cases that motivated #168.

### Compatibility

The experimental `aspects` field predates the minimum supported DataHub (1.3.x). On instances where it is unavailable or unauthorized, the read degrades to empty rather than erroring.

## Testing

- `make verify` passes (lint/43 linters, `go test -race -shuffle=on`, coverage + patch-coverage ≥80%, gosec + govulncheck, `make schema-check`, mutation, build-check).
- New unit tests:
  - `TestClientGetEntityRawAspectsTagsTerms` — tags/terms populated from raw aspect payloads
  - `TestClientGetEntityRawAspectsGracefulDegradation` — `GetEntity` returns the entity with empty tags/terms when the aspect read errors
  - `TestApplyRawAspects` — precedence (typed values not overwritten), malformed payloads, empty-URN skipping, unknown aspect names

🤖 Generated with [Claude Code](https://claude.com/claude-code)