### PR TITLE
feat(client): tag descriptions and custom properties (#173)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,12 +120,12 @@ All are customizable via the three-tier priority pattern.
 
 ### Write Tools (require `WriteEnabled: true`)
 
-3 CRUD tools using the discriminator pattern (`what` parameter) to cover 35 operations:
+3 CRUD tools using the discriminator pattern (`what` parameter) to cover 37 operations:
 
 | Tool | Title | Operations | Description |
 |------|-------|------------|-------------|
 | `datahub_create` | Create Entity | 10 | Create tags, domains, glossary terms, data products, documents, applications, queries, incidents, structured properties, data contracts |
-| `datahub_update` | Update Entity | 17 | Update descriptions, tags, glossary terms, links, owners, domains, structured properties, incidents, queries, document contents/status/related entities/sub-type, data contracts |
+| `datahub_update` | Update Entity | 19 | Update descriptions (including tag/glossaryTerm descriptions), tags, glossary terms, links, owners, domains, structured properties, custom properties, incidents, queries, document contents/status/related entities/sub-type, data contracts |
 | `datahub_delete` | Delete Entity | 8 | Delete queries, tags, domains, glossary entities, data products, applications, documents, structured properties |
 
 ## Description Overrides

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ See the [library documentation](https://mcp-datahub.txn2.com/library/) for compl
 
 ### Write Tools (require `DATAHUB_WRITE_ENABLED=true`)
 
-3 CRUD tools using the `what` discriminator pattern — 35 operations total:
+3 CRUD tools using the `what` discriminator pattern — 37 operations total:
 
 | Tool | Operations | Description |
 |------|------------|-------------|
 | `datahub_create` | 10 | Create tags, domains, glossary terms, data products, documents, applications, queries, incidents, structured properties, data contracts |
-| `datahub_update` | 17 | Update descriptions, tags, glossary terms, links, owners, domains, structured properties, incidents, queries, documents, data contracts |
+| `datahub_update` | 19 | Update descriptions (including tag/glossaryTerm descriptions), tags, glossary terms, links, owners, domains, structured properties, custom properties, incidents, queries, documents, data contracts |
 | `datahub_delete` | 8 | Delete queries, tags, domains, glossary entities, data products, applications, documents, structured properties |
 
 Write tools are disabled by default for safety.

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -705,7 +705,7 @@ Update metadata on an existing entity.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `what` | string | Yes | What to update (see table below) |
-| `action` | string | Varies | `add`/`remove` (required for tag, glossary_term, link, owner); `set`/`remove` (domain, structured_properties, default: set); not used for other what values |
+| `action` | string | Varies | `add`/`remove` (required for tag, glossary_term, link, owner); `set`/`remove` (domain, structured_properties, custom_properties, default: set); not used for other what values |
 | `urn` | string | Yes | Entity URN |
 | `value` | string | No | New value (description, status, label, message) |
 | `target_urn` | string | No | Target URN for add/remove (tag, glossary term, owner, domain) |
@@ -716,6 +716,8 @@ Update metadata on an existing entity.
 | `ownership_type` | string | No | Ownership type, e.g. TECHNICAL_OWNER (owner add only) |
 | `properties` | object[] | No | Structured property values to set (structured_properties) |
 | `property_urns` | string[] | No | Property URNs to remove (structured_properties) |
+| `custom_properties` | object | No | Legacy customProperties key/values to set (custom_properties, action=set) |
+| `property_keys` | string[] | No | Legacy customProperties keys to remove (custom_properties, action=remove) |
 | `language` | string | No | Query language (query only) |
 | `dataset_urns` | string[] | No | Dataset URNs (query, data_contract) |
 | `incident_type` | string | No | Incident type (incident only) |
@@ -733,7 +735,7 @@ Update metadata on an existing entity.
 
 | what | action | Description |
 |------|--------|-------------|
-| `description` | _(not used)_ | Set entity description |
+| `description` | _(not used)_ | Set entity description (also edits tag and glossaryTerm descriptions) |
 | `column_description` | _(not used)_ | Set schema field description |
 | `tag` | **required**: add/remove | Add or remove a tag |
 | `glossary_term` | **required**: add/remove | Add or remove a glossary term |
@@ -741,6 +743,7 @@ Update metadata on an existing entity.
 | `owner` | **required**: add/remove | Add or remove an owner |
 | `domain` | set/remove (default: set) | Set or remove domain assignment |
 | `structured_properties` | set/remove (default: set) | Set or remove structured property values |
+| `custom_properties` | set/remove (default: set) | Set or remove legacy customProperties key/values |
 | `structured_property` | _(not used)_ | Update a structured property definition |
 | `incident_status` | _(not used)_ | Update incident status (requires `state`) |
 | `incident` | _(not used)_ | Update incident details |

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -36,4 +36,8 @@ var (
 
 	// ErrUnsupportedLinkEntity indicates the entity type does not support link operations.
 	ErrUnsupportedLinkEntity = errors.New("entity type does not support link operations")
+
+	// ErrUnsupportedCustomPropertiesEntity indicates the entity type has no aspect that
+	// carries the legacy customProperties map.
+	ErrUnsupportedCustomPropertiesEntity = errors.New("entity type does not support custom properties operations")
 )

--- a/pkg/client/rest.go
+++ b/pkg/client/rest.go
@@ -23,9 +23,17 @@ func (c *Client) restBaseURL() string {
 	return strings.TrimSuffix(c.endpoint, "/api/graphql")
 }
 
-// aspectResponse represents the response from GET /aspects endpoint.
+// aspectResponse represents the OpenAPI v3 GET response: {"value": {...}}.
 type aspectResponse struct {
 	Value json.RawMessage `json:"value"`
+}
+
+// v1AspectResponse represents the legacy Rest.li GET response, which wraps the
+// aspect under its fully-qualified class name: {"aspect":{"<FQCN>": {...}}}.
+// Value tolerates a normalized flat {"value": {...}} body from proxies.
+type v1AspectResponse struct {
+	Aspect map[string]json.RawMessage `json:"aspect"`
+	Value  json.RawMessage            `json:"value"`
 }
 
 // ingestProposal represents a metadata change proposal for the REST API.
@@ -89,23 +97,51 @@ func (c *Client) getAspect(ctx context.Context, entityType, entityURN, aspectNam
 		"status", resp.StatusCode,
 		"response_size", len(body))
 
-	if err := c.checkRESTStatus(resp.StatusCode, body); err != nil {
+	if err = c.checkRESTStatus(resp.StatusCode, body); err != nil {
 		return nil, err
 	}
 
-	var aspectResp aspectResponse
-	if err := json.Unmarshal(body, &aspectResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal aspect response: %w", err)
+	value, err := c.extractAspectValue(body)
+	if err != nil {
+		return nil, err
 	}
 
 	// DataHub may return 200 OK with a null or empty value when the entity
 	// exists but the requested aspect has never been written. Treat this the
 	// same as 404 so callers initialize a default struct.
-	if isNullOrEmptyJSON(aspectResp.Value) {
+	if isNullOrEmptyJSON(value) {
 		return nil, ErrNotFound
 	}
 
-	return aspectResp.Value, nil
+	return value, nil
+}
+
+// extractAspectValue pulls the flat aspect JSON out of a GET response.
+// The OpenAPI v3 endpoint wraps it as {"value": {...}}. The legacy v1 Rest.li
+// endpoint wraps it as {"version":N,"aspect":{"<fully.qualified.ClassName>": {...}}}.
+// Parsing only the v3 shape for both left v1 read-modify-write starting from an
+// empty aspect, silently dropping existing fields on write-back.
+func (c *Client) extractAspectValue(body []byte) (json.RawMessage, error) {
+	if c.config.isV3() {
+		var resp aspectResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal aspect response: %w", err)
+		}
+		return resp.Value, nil
+	}
+
+	var resp v1AspectResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal aspect response: %w", err)
+	}
+	// The "aspect" object holds exactly one entry keyed by the aspect's
+	// fully-qualified PDL class name; return its value regardless of the key.
+	for _, raw := range resp.Aspect {
+		return raw, nil
+	}
+	// Tolerate a flat {"value": {...}} body as well (some gateways/proxies
+	// normalize the envelope); real Rest.li responses always use "aspect".
+	return resp.Value, nil
 }
 
 // postIngestProposal posts a metadata change proposal to the DataHub REST API.
@@ -151,8 +187,14 @@ func (c *Client) postAspectV1(ctx context.Context, proposal ingestProposal) erro
 }
 
 // postAspectV3 sends an aspect update via the OpenAPI v3 endpoint.
+//
+// createIfNotExists=false forces UPSERT semantics. Without it, DataHub defaults the
+// OpenAPI v3 write to a CREATE, which fails with HTTP 400 ("Cannot perform CREATE
+// since the aspect already exists") whenever the target aspect is already present.
+// Every write in this client is a read-modify-write UPSERT, so create-only semantics
+// are never wanted; the flag makes writes succeed whether the aspect exists or not.
 func (c *Client) postAspectV3(ctx context.Context, proposal ingestProposal) error {
-	reqURL := fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s",
+	reqURL := fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s?createIfNotExists=false",
 		c.restBaseURL(), proposal.EntityType,
 		url.PathEscape(proposal.EntityURN), proposal.AspectName)
 

--- a/pkg/client/rest_test.go
+++ b/pkg/client/rest_test.go
@@ -710,6 +710,36 @@ func TestGetAspect_V3_NotFound(t *testing.T) {
 	}
 }
 
+// TestGetAspect_V1_RestLiEnvelope verifies the client parses the REAL legacy
+// Rest.li GET envelope ({"aspect":{"<FQCN>":{...}}}) and does not start from an
+// empty aspect. This is the shape a live DataHub returns on the v1 path; parsing
+// only {"value":...} caused read-modify-write to silently drop existing fields.
+func TestGetAspect_V1_RestLiEnvelope(t *testing.T) {
+	inner := `{"name":"n","definition":"d","termSource":"INTERNAL","customProperties":{"k":"v"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// No "value" key — only the Rest.li "aspect" wrapper.
+		_, _ = w.Write([]byte(`{"version":0,"aspect":{"com.linkedin.glossary.GlossaryTermInfo":` + inner + `}}`))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		config:     Config{APIVersion: APIVersionV1},
+		logger:     NopLogger{},
+	}
+
+	raw, err := c.getAspect(context.Background(), "glossaryTerm", "urn:li:glossaryTerm:x", "glossaryTermInfo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(raw) != inner {
+		t.Errorf("got %s, want %s", string(raw), inner)
+	}
+}
+
 func TestPostIngestProposal_V3(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -720,6 +750,11 @@ func TestPostIngestProposal_V3(t *testing.T) {
 		wantPath := "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3Atest/globalTags"
 		if r.URL.RawPath != wantPath && r.URL.Path != "/openapi/v3/entity/dataset/urn:li:dataset:test/globalTags" {
 			t.Errorf("unexpected path: raw=%q path=%q, want %q", r.URL.RawPath, r.URL.Path, wantPath)
+		}
+
+		// UPSERT semantics: createIfNotExists=false so writes to existing aspects succeed.
+		if got := r.URL.Query().Get("createIfNotExists"); got != "false" {
+			t.Errorf("expected createIfNotExists=false, got %q", got)
 		}
 
 		// No RestLi header

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -10,7 +10,7 @@ import (
 
 // ErrUnsupportedEntityType is returned when an entity type does not support description updates.
 // Entity types intentionally excluded (no editable description aspect in DataHub):
-// tag, corpuser, corpGroup, mlModel, mlModelGroup, notebook.
+// corpuser, corpGroup, mlModel, mlModelGroup, notebook.
 var ErrUnsupportedEntityType = errors.New("unsupported entity type for description update")
 
 // Entity type constants used in aspect maps and URN parsing.
@@ -26,6 +26,7 @@ const (
 	entityTypeGlossaryTerm = "glossaryTerm"
 	entityTypeDomain       = "domain"
 	entityTypeDocument     = "document"
+	entityTypeTag          = "tag"
 )
 
 // entityTypeFromURN derives the DataHub entity type string from a parsed URN.
@@ -50,6 +51,8 @@ type DescriptionAspectInfo struct {
 // glossaryNode uses "definition" instead of "description".
 // dataProduct uses its non-editable property aspect (dataProductProperties).
 // domain uses domainProperties and glossaryTerm uses glossaryTermInfo.
+// tag uses tagProperties, but is written via the GraphQL updateDescription
+// mutation (see graphQLWriteTypes) rather than a REST aspect write.
 var descriptionAspectMap = map[string]DescriptionAspectInfo{
 	entityTypeDataset:      {AspectName: "editableDatasetProperties", FieldName: "description"},
 	entityTypeDashboard:    {AspectName: "editableDashboardProperties", FieldName: "description"},
@@ -61,6 +64,7 @@ var descriptionAspectMap = map[string]DescriptionAspectInfo{
 	entityTypeGlossaryNode: {AspectName: "glossaryNodeInfo", FieldName: "definition"},
 	entityTypeDomain:       {AspectName: "domainProperties", FieldName: "description"},
 	entityTypeGlossaryTerm: {AspectName: "glossaryTermInfo", FieldName: "definition"},
+	entityTypeTag:          {AspectName: "tagProperties", FieldName: "description"},
 }
 
 // globalTagsSupportedTypes lists entity types that support the globalTags aspect.

--- a/pkg/client/write_custom_properties.go
+++ b/pkg/client/write_custom_properties.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// customPropertiesAspectMap maps DataHub entity types to the aspect that carries
+// their legacy customProperties map. These are the non-editable "properties"/"info"
+// aspects that mix in CustomProperties (verified against the upstream DataHub PDL
+// models). tag is intentionally absent: tagProperties has no customProperties field.
+//
+// Writes use REST read-modify-write (getAspect + postIngestProposal) because DataHub
+// exposes no GraphQL mutation for arbitrary customProperties. All existing aspect
+// fields are preserved via descriptionAspect's map representation, so required fields
+// on these aspects (for example glossaryTermInfo.termSource) survive the round-trip.
+var customPropertiesAspectMap = map[string]string{
+	entityTypeDataset:      "datasetProperties",
+	entityTypeDashboard:    "dashboardInfo",
+	entityTypeChart:        "chartInfo",
+	entityTypeDataFlow:     "dataFlowInfo",
+	entityTypeDataJob:      "dataJobInfo",
+	entityTypeContainer:    "containerProperties",
+	entityTypeDataProduct:  "dataProductProperties",
+	entityTypeGlossaryNode: "glossaryNodeInfo",
+	entityTypeGlossaryTerm: "glossaryTermInfo",
+	entityTypeDomain:       "domainProperties",
+}
+
+// customProperties extracts the customProperties map from the aspect.
+// Returns an empty map when the field is absent or null.
+func (a *descriptionAspect) customProperties() (map[string]string, error) {
+	raw, ok := a.fields["customProperties"]
+	if !ok || isNullOrEmptyJSON(raw) {
+		return map[string]string{}, nil
+	}
+
+	var props map[string]string
+	if err := json.Unmarshal(raw, &props); err != nil {
+		return nil, fmt.Errorf("parsing customProperties: %w", err)
+	}
+	if props == nil {
+		props = map[string]string{}
+	}
+	return props, nil
+}
+
+// setCustomProperties writes the customProperties map back into the aspect,
+// preserving all other fields of the read-modify-write cycle.
+func (a *descriptionAspect) setCustomProperties(props map[string]string) error {
+	encoded, err := json.Marshal(props)
+	if err != nil {
+		return fmt.Errorf("encoding customProperties: %w", err)
+	}
+	a.fields["customProperties"] = encoded
+	return nil
+}
+
+// SetCustomProperties sets or overwrites the given legacy customProperties key/values
+// on an entity. Keys not listed in properties are left untouched. This is the legacy
+// customProperties map, distinct from structured properties (see UpsertStructuredProperties).
+func (c *Client) SetCustomProperties(ctx context.Context, urn string, properties map[string]string) error {
+	if err := c.mutateCustomProperties(ctx, urn, func(current map[string]string) {
+		for key, value := range properties {
+			current[key] = value
+		}
+	}); err != nil {
+		return fmt.Errorf("SetCustomProperties: %w", err)
+	}
+	return nil
+}
+
+// RemoveCustomProperties removes the given keys from an entity's legacy customProperties
+// map. Keys that are not present are ignored.
+func (c *Client) RemoveCustomProperties(ctx context.Context, urn string, keys []string) error {
+	if err := c.mutateCustomProperties(ctx, urn, func(current map[string]string) {
+		for _, key := range keys {
+			delete(current, key)
+		}
+	}); err != nil {
+		return fmt.Errorf("RemoveCustomProperties: %w", err)
+	}
+	return nil
+}
+
+// mutateCustomProperties applies mutate to an entity's current customProperties map
+// using REST read-modify-write, then writes the properties aspect back.
+func (c *Client) mutateCustomProperties(
+	ctx context.Context, urn string, mutate func(map[string]string),
+) error {
+	entityType, err := entityTypeFromURN(urn)
+	if err != nil {
+		return err
+	}
+
+	aspectName, ok := customPropertiesAspectMap[entityType]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnsupportedCustomPropertiesEntity, entityType)
+	}
+
+	props, err := c.readEditableProperties(ctx, entityType, urn, aspectName)
+	if err != nil {
+		return err
+	}
+
+	// The REST GET of dataProductProperties omits the display name; preserve it so
+	// the write does not reset the name to the URN slug (mirrors UpdateDescription).
+	if entityType == entityTypeDataProduct {
+		if err = c.preserveDataProductName(ctx, urn, props); err != nil {
+			return err
+		}
+	}
+
+	current, err := props.customProperties()
+	if err != nil {
+		return err
+	}
+
+	mutate(current)
+
+	if err := props.setCustomProperties(current); err != nil {
+		return err
+	}
+
+	return c.postIngestProposal(ctx, ingestProposal{
+		EntityType: entityType,
+		EntityURN:  urn,
+		AspectName: aspectName,
+		Aspect:     props,
+	})
+}

--- a/pkg/client/write_custom_properties_test.go
+++ b/pkg/client/write_custom_properties_test.go
@@ -1,0 +1,188 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// customPropsFromProposal decodes the customProperties map written by an ingest proposal.
+func customPropsFromProposal(t *testing.T, aspectJSON string) map[string]string {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(aspectJSON), &fields); err != nil {
+		t.Fatalf("failed to unmarshal inner aspect: %v", err)
+	}
+	raw, ok := fields["customProperties"]
+	if !ok {
+		t.Fatal("customProperties field missing from written aspect")
+	}
+	var props map[string]string
+	if err := json.Unmarshal(raw, &props); err != nil {
+		t.Fatalf("failed to unmarshal customProperties: %v", err)
+	}
+	return props
+}
+
+func TestSetCustomProperties_MergesAndPreserves(t *testing.T) {
+	var gotProps map[string]string
+	var gotAspect, gotEntityType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// Existing aspect carries a required field plus an existing custom property.
+			propsJSON := `{"definition":"a term","termSource":"INTERNAL",` +
+				`"customProperties":{"existing":"keep","source_system":"legacy"}}`
+			resp := aspectResponse{Value: json.RawMessage(propsJSON)}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		proposal, aspectJSON := extractProposalWireFormat(t, r.Body)
+		gotEntityType, _ = proposal["entityType"].(string)
+		gotAspect, _ = proposal["aspectName"].(string)
+		gotProps = customPropsFromProposal(t, aspectJSON)
+
+		// Required field must survive the read-modify-write cycle.
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(aspectJSON), &fields); err != nil {
+			t.Fatalf("failed to unmarshal aspect: %v", err)
+		}
+		if _, ok := fields["termSource"]; !ok {
+			t.Error("termSource required field was not preserved")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.SetCustomProperties(context.Background(), "urn:li:glossaryTerm:revenue",
+		map[string]string{"source_system": "warehouse", "owner": "data-team"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotEntityType != "glossaryTerm" {
+		t.Errorf("entityType = %q, want glossaryTerm", gotEntityType)
+	}
+	if gotAspect != "glossaryTermInfo" {
+		t.Errorf("aspectName = %q, want glossaryTermInfo", gotAspect)
+	}
+	want := map[string]string{"existing": "keep", "source_system": "warehouse", "owner": "data-team"}
+	if len(gotProps) != len(want) {
+		t.Fatalf("customProperties = %v, want %v", gotProps, want)
+	}
+	for k, v := range want {
+		if gotProps[k] != v {
+			t.Errorf("customProperties[%q] = %q, want %q", k, gotProps[k], v)
+		}
+	}
+}
+
+func TestRemoveCustomProperties_DeletesKeys(t *testing.T) {
+	var gotProps map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			propsJSON := `{"name":"orders","customProperties":{"source_system":"legacy","keep":"me"}}`
+			resp := aspectResponse{Value: json.RawMessage(propsJSON)}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		_, aspectJSON := extractProposalWireFormat(t, r.Body)
+		gotProps = customPropsFromProposal(t, aspectJSON)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.RemoveCustomProperties(context.Background(),
+		"urn:li:dataset:(urn:li:dataPlatform:hive,db.orders,PROD)",
+		[]string{"source_system", "absent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := gotProps["source_system"]; ok {
+		t.Error("source_system should have been removed")
+	}
+	if gotProps["keep"] != "me" {
+		t.Errorf("keep = %q, want me", gotProps["keep"])
+	}
+}
+
+func TestSetCustomProperties_NoExistingAspect(t *testing.T) {
+	var gotProps map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, aspectJSON := extractProposalWireFormat(t, r.Body)
+		gotProps = customPropsFromProposal(t, aspectJSON)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		endpoint:   server.URL + "/api/graphql",
+		token:      "test-token",
+		httpClient: server.Client(),
+		logger:     NopLogger{},
+	}
+
+	err := c.SetCustomProperties(context.Background(),
+		"urn:li:dataset:(urn:li:dataPlatform:hive,db.t,PROD)",
+		map[string]string{"a": "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotProps["a"] != "b" {
+		t.Errorf("customProperties[a] = %q, want b", gotProps["a"])
+	}
+}
+
+func TestCustomProperties_UnsupportedEntityType(t *testing.T) {
+	c := &Client{logger: NopLogger{}}
+
+	// tag has no customProperties field on tagProperties.
+	if err := c.SetCustomProperties(context.Background(), "urn:li:tag:PII",
+		map[string]string{"a": "b"}); err == nil {
+		t.Fatal("expected error for tag entity")
+	} else if !errors.Is(err, ErrUnsupportedCustomPropertiesEntity) {
+		t.Errorf("expected ErrUnsupportedCustomPropertiesEntity, got: %v", err)
+	}
+
+	if err := c.RemoveCustomProperties(context.Background(), "urn:li:corpuser:jdoe",
+		[]string{"a"}); err == nil {
+		t.Fatal("expected error for corpuser entity")
+	} else if !errors.Is(err, ErrUnsupportedCustomPropertiesEntity) {
+		t.Errorf("expected ErrUnsupportedCustomPropertiesEntity, got: %v", err)
+	}
+}
+
+func TestCustomProperties_InvalidURN(t *testing.T) {
+	c := &Client{logger: NopLogger{}}
+	if err := c.SetCustomProperties(context.Background(), "not-a-urn",
+		map[string]string{"a": "b"}); err == nil {
+		t.Fatal("expected error for invalid URN")
+	}
+}

--- a/pkg/client/write_graphql.go
+++ b/pkg/client/write_graphql.go
@@ -55,11 +55,17 @@ mutation updateDescription($input: DescriptionUpdateInput!) {
 // graphQLWriteTypes lists entity types that require GraphQL mutations for write
 // operations because the REST API does not support their aspects (globalTags,
 // glossaryTerms, editable description).
+//
+// tag is included for description writes only: DataHub's updateDescription
+// GraphQL mutation routes a tag URN to tagProperties.description internally.
+// Tag association operations (AddTag/RemoveTag) do not apply to tag entities and
+// are rejected earlier by globalTagsSupportedTypes, so this entry is safe.
 var graphQLWriteTypes = map[string]bool{
 	entityTypeDomain:       true,
 	entityTypeGlossaryTerm: true,
 	entityTypeGlossaryNode: true,
 	entityTypeDocument:     true,
+	entityTypeTag:          true,
 }
 
 // addTagGraphQL adds a tag to an entity using the GraphQL addTag mutation.

--- a/pkg/client/write_graphql_test.go
+++ b/pkg/client/write_graphql_test.go
@@ -260,6 +260,12 @@ func TestUpdateDescriptionGraphQL(t *testing.T) {
 			response:    `{"data": {"updateDescription": true}}`,
 		},
 		{
+			name:        "tag entity",
+			urn:         "urn:li:tag:PII",
+			description: "Personally identifiable information",
+			response:    `{"data": {"updateDescription": true}}`,
+		},
+		{
 			name:        "graphql error",
 			urn:         "urn:li:domain:engineering",
 			description: "Updated",
@@ -373,7 +379,7 @@ func TestAddTag_DatasetStillUsesREST(t *testing.T) {
 
 func TestGraphQLWriteTypes(t *testing.T) {
 	// Verify the graphQLWriteTypes map has the correct entries.
-	expected := []string{"domain", "glossaryTerm", "glossaryNode"}
+	expected := []string{"domain", "glossaryTerm", "glossaryNode", "tag"}
 	for _, et := range expected {
 		if !graphQLWriteTypes[et] {
 			t.Errorf("expected %q in graphQLWriteTypes", et)

--- a/pkg/client/write_test.go
+++ b/pkg/client/write_test.go
@@ -1272,8 +1272,9 @@ func TestLookupDescriptionAspect(t *testing.T) {
 		{"glossaryNode", "glossaryNodeInfo", "definition", false},
 		{"domain", "domainProperties", "description", false},
 		{"glossaryTerm", "glossaryTermInfo", "definition", false},
+		// tag is supported for descriptions via the GraphQL updateDescription path.
+		{"tag", "tagProperties", "description", false},
 		// Unsupported types return errors
-		{"tag", "", "", true},
 		{"corpuser", "", "", true},
 	}
 
@@ -1397,7 +1398,8 @@ func TestUpdateDescription_EntityTypes(t *testing.T) {
 
 func TestUpdateDescription_UnsupportedEntityType(t *testing.T) {
 	c := &Client{logger: NopLogger{}}
-	err := c.UpdateDescription(context.Background(), "urn:li:tag:PII", "desc")
+	// corpuser has no editable description aspect and no GraphQL routing.
+	err := c.UpdateDescription(context.Background(), "urn:li:corpuser:jdoe", "desc")
 	if err == nil {
 		t.Fatal("expected error for unsupported entity type")
 	}

--- a/pkg/tools/client_interface.go
+++ b/pkg/tools/client_interface.go
@@ -103,6 +103,14 @@ type DataHubClient interface {
 	// RemoveStructuredProperties removes structured properties from an entity.
 	RemoveStructuredProperties(ctx context.Context, urn string, propertyURNs []string) error
 
+	// Custom properties (legacy customProperties map, distinct from structured properties).
+
+	// SetCustomProperties sets or overwrites legacy customProperties key/values on an entity.
+	SetCustomProperties(ctx context.Context, urn string, properties map[string]string) error
+
+	// RemoveCustomProperties removes legacy customProperties keys from an entity.
+	RemoveCustomProperties(ctx context.Context, urn string, keys []string) error
+
 	// Incidents (DataHub 1.3.x+).
 
 	// GetIncidents retrieves active incidents for an entity.

--- a/pkg/tools/descriptions.go
+++ b/pkg/tools/descriptions.go
@@ -58,10 +58,11 @@ var defaultDescriptions = map[ToolName]string{
 
 	ToolUpdate: "Update metadata on an existing DataHub entity. Set 'what' to choose what to update. " +
 		"For tag/glossary_term/link/owner: 'action' is required (add or remove). " +
-		"For domain/structured_properties: 'action' defaults to set (set or remove). " +
-		"Other what values do not use 'action'. Supports: description, column_description, " +
+		"For domain/structured_properties/custom_properties: 'action' defaults to set (set or remove). " +
+		"Other what values do not use 'action'. 'description' also edits tag and glossaryTerm descriptions. " +
+		"Supports: description, column_description, " +
 		"tag, glossary_term, link, owner, domain, structured_properties, structured_property, " +
-		"incident_status, incident, query, document_contents, document_status, " +
+		"custom_properties, incident_status, incident, query, document_contents, document_status, " +
 		"document_related_entities, document_sub_type, and data_contract.",
 
 	ToolDelete: "Delete an entity or resource from DataHub. Set 'what' to choose the entity type: " +

--- a/pkg/tools/toolkit_test.go
+++ b/pkg/tools/toolkit_test.go
@@ -40,6 +40,8 @@ type mockClient struct {
 	listStructuredPropertyDefinitionsFunc func(ctx context.Context) ([]types.StructuredPropertyDefinition, error)
 	upsertStructuredPropertiesFunc        func(ctx context.Context, urn string, properties []types.StructuredPropertyInput) error
 	removeStructuredPropertiesFunc        func(ctx context.Context, urn string, propertyURNs []string) error
+	setCustomPropertiesFunc               func(ctx context.Context, urn string, properties map[string]string) error
+	removeCustomPropertiesFunc            func(ctx context.Context, urn string, keys []string) error
 	getIncidentsFunc                      func(ctx context.Context, urn string) (*types.IncidentResult, error)
 	raiseIncidentFunc                     func(ctx context.Context, input types.RaiseIncidentInput) (string, error)
 	updateIncidentStatusFunc              func(ctx context.Context, incidentURN, state, message string) error
@@ -261,6 +263,20 @@ func (m *mockClient) UpsertStructuredProperties(ctx context.Context, urn string,
 func (m *mockClient) RemoveStructuredProperties(ctx context.Context, urn string, propertyURNs []string) error {
 	if m.removeStructuredPropertiesFunc != nil {
 		return m.removeStructuredPropertiesFunc(ctx, urn, propertyURNs)
+	}
+	return nil
+}
+
+func (m *mockClient) SetCustomProperties(ctx context.Context, urn string, properties map[string]string) error {
+	if m.setCustomPropertiesFunc != nil {
+		return m.setCustomPropertiesFunc(ctx, urn, properties)
+	}
+	return nil
+}
+
+func (m *mockClient) RemoveCustomProperties(ctx context.Context, urn string, keys []string) error {
+	if m.removeCustomPropertiesFunc != nil {
+		return m.removeCustomPropertiesFunc(ctx, urn, keys)
 	}
 	return nil
 }

--- a/pkg/tools/write_update.go
+++ b/pkg/tools/write_update.go
@@ -12,10 +12,10 @@ import (
 // UpdateInput is the input for the datahub_update tool.
 type UpdateInput struct {
 	//nolint:lll // struct tag cannot be split
-	What string `json:"what" jsonschema_description:"What to update: description, column_description, tag, glossary_term, link, owner, domain, structured_properties, structured_property, incident_status, incident, query, document_contents, document_status, document_related_entities, document_sub_type, or data_contract" jsonschema_enum:"description,column_description,tag,glossary_term,link,owner,domain,structured_properties,structured_property,incident_status,incident,query,document_contents,document_status,document_related_entities,document_sub_type,data_contract"`
+	What string `json:"what" jsonschema_description:"What to update: description (also updates tag/glossaryTerm descriptions), column_description, tag, glossary_term, link, owner, domain, structured_properties, structured_property, custom_properties, incident_status, incident, query, document_contents, document_status, document_related_entities, document_sub_type, or data_contract" jsonschema_enum:"description,column_description,tag,glossary_term,link,owner,domain,structured_properties,structured_property,custom_properties,incident_status,incident,query,document_contents,document_status,document_related_entities,document_sub_type,data_contract"`
 
 	//nolint:lll // struct tag cannot be split
-	Action string `json:"action,omitempty" jsonschema_description:"Action: add/remove (tag, glossary_term, link, owner), set/remove (domain, structured_properties), not used for other what values" jsonschema_enum:"add,remove,set"`
+	Action string `json:"action,omitempty" jsonschema_description:"Action: add/remove (tag, glossary_term, link, owner), set/remove (domain, structured_properties, custom_properties), not used for other what values" jsonschema_enum:"add,remove,set"`
 
 	// Entity identification
 	URN string `json:"urn" jsonschema_description:"URN of the entity to update"`
@@ -38,6 +38,12 @@ type UpdateInput struct {
 	// Structured properties on assets
 	Properties   []types.StructuredPropertyInput `json:"properties,omitempty" jsonschema_description:"Structured property values to set"`
 	PropertyURNs []string                        `json:"property_urns,omitempty" jsonschema_description:"Property URNs to remove"`
+
+	// Legacy custom properties (custom_properties what)
+	//nolint:lll // struct tag cannot be split
+	CustomProperties map[string]string `json:"custom_properties,omitempty" jsonschema_description:"Legacy customProperties key/values to set (custom_properties, action=set)"`
+	//nolint:lll // struct tag cannot be split
+	PropertyKeys []string `json:"property_keys,omitempty" jsonschema_description:"Legacy customProperties keys to remove (custom_properties, action=remove)"`
 
 	// Query-specific
 	Name        string   `json:"name,omitempty" jsonschema_description:"Updated name (query, incident, structured_property)"`
@@ -161,6 +167,9 @@ func (t *Toolkit) dispatchUpdateMetadata(
 		return updateResult{out, err}, true
 	case "structured_properties":
 		out, err := t.handleUpdateStructuredProperties(ctx, c, input, action)
+		return updateResult{out, err}, true
+	case "custom_properties":
+		out, err := t.handleUpdateCustomProperties(ctx, c, input, action)
 		return updateResult{out, err}, true
 	default:
 		return updateResult{}, false

--- a/pkg/tools/write_update_handlers.go
+++ b/pkg/tools/write_update_handlers.go
@@ -198,6 +198,34 @@ func (t *Toolkit) handleUpdateStructuredProperties(
 	}
 }
 
+func (t *Toolkit) handleUpdateCustomProperties(
+	ctx context.Context, c DataHubClient, input UpdateInput, action string,
+) (UpdateOutput, error) {
+	if action == "" {
+		action = actionSet
+	}
+	switch action {
+	case actionSet:
+		if len(input.CustomProperties) == 0 {
+			return UpdateOutput{}, errRequired("custom_properties")
+		}
+		if err := c.SetCustomProperties(ctx, input.URN, input.CustomProperties); err != nil {
+			return UpdateOutput{}, err
+		}
+		return UpdateOutput{URN: input.URN, What: "custom_properties", Action: "updated"}, nil
+	case actionRemove:
+		if len(input.PropertyKeys) == 0 {
+			return UpdateOutput{}, errRequired("property_keys")
+		}
+		if err := c.RemoveCustomProperties(ctx, input.URN, input.PropertyKeys); err != nil {
+			return UpdateOutput{}, err
+		}
+		return UpdateOutput{URN: input.URN, What: "custom_properties", Action: "removed"}, nil
+	default:
+		return UpdateOutput{}, errInvalidAction(action, "set", "remove")
+	}
+}
+
 func (t *Toolkit) handleUpdateStructuredProperty(
 	ctx context.Context, c DataHubClient, input UpdateInput,
 ) (UpdateOutput, error) {

--- a/pkg/tools/write_update_test.go
+++ b/pkg/tools/write_update_test.go
@@ -206,6 +206,18 @@ func TestHandleUpdate_MetadataOperations(t *testing.T) {
 			What: "structured_properties", URN: urn,
 			Properties: []types.StructuredPropertyInput{{PropertyURN: "urn:li:sp:test", Values: []any{"v"}}},
 		}, "structured_properties", "updated", ""},
+		{"custom_properties_set", UpdateInput{
+			What: "custom_properties", Action: "set", URN: urn,
+			CustomProperties: map[string]string{"source_system": "warehouse"},
+		}, "custom_properties", "updated", ""},
+		{"custom_properties_remove", UpdateInput{
+			What: "custom_properties", Action: "remove", URN: urn,
+			PropertyKeys: []string{"source_system"},
+		}, "custom_properties", "removed", ""},
+		{"custom_properties_default_action", UpdateInput{
+			What: "custom_properties", URN: urn,
+			CustomProperties: map[string]string{"a": "b"},
+		}, "custom_properties", "updated", ""},
 	}
 
 	for _, tt := range tests {
@@ -300,6 +312,16 @@ func TestHandleUpdate_MissingRequiredFields(t *testing.T) {
 		{"structured_properties_remove_empty", UpdateInput{
 			What: "structured_properties", Action: "remove", URN: urn,
 		}},
+		{"custom_properties_invalid_action", UpdateInput{
+			What: "custom_properties", Action: "add", URN: urn,
+			CustomProperties: map[string]string{"a": "b"},
+		}},
+		{"custom_properties_set_empty", UpdateInput{
+			What: "custom_properties", Action: "set", URN: urn,
+		}},
+		{"custom_properties_remove_empty", UpdateInput{
+			What: "custom_properties", Action: "remove", URN: urn,
+		}},
 	}
 
 	for _, tt := range tests {
@@ -334,5 +356,35 @@ func TestHandleUpdate_ClientErrorPropagation(t *testing.T) {
 	}
 	if tc.Text == "" {
 		t.Error("error message should not be empty")
+	}
+}
+
+func TestHandleUpdate_CustomPropertiesClientErrorPropagation(t *testing.T) {
+	clientErr := errors.New("DataHub API error")
+	mock := &mockClient{
+		setCustomPropertiesFunc: func(_ context.Context, _ string, _ map[string]string) error {
+			return clientErr
+		},
+		removeCustomPropertiesFunc: func(_ context.Context, _ string, _ []string) error {
+			return clientErr
+		},
+	}
+	toolkit := NewToolkit(mock, Config{WriteEnabled: true})
+	urn := "urn:li:glossaryTerm:revenue"
+
+	setResult, _, _ := toolkit.handleUpdate(context.Background(), nil, UpdateInput{
+		What: "custom_properties", Action: "set", URN: urn,
+		CustomProperties: map[string]string{"a": "b"},
+	})
+	if !setResult.IsError {
+		t.Error("expected error when SetCustomProperties fails")
+	}
+
+	removeResult, _, _ := toolkit.handleUpdate(context.Background(), nil, UpdateInput{
+		What: "custom_properties", Action: "remove", URN: urn,
+		PropertyKeys: []string{"a"},
+	})
+	if !removeResult.IsError {
+		t.Error("expected error when RemoveCustomProperties fails")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #173.

Adds the two client capabilities the downstream `mcp-data-platform` curation flow (`apply_knowledge`) needs, and — because these were validated end-to-end against a live DataHub — fixes two pre-existing write-path bugs that the validation surfaced.

Everything here was **live-validated against DataHub v1.6.0 (latest OSS)** on **both** the v1 (Rest.li) and v3 (OpenAPI) API paths.

## What's in scope

### 1. Edit a tag's description (#173, part 1)
`Client.UpdateDescription` now accepts `urn:li:tag:...`. Tags are routed through the GraphQL `updateDescription` mutation (the same path already used for domain/glossaryTerm/glossaryNode), verified against DataHub's `UpdateDescriptionResolver`, which dispatches `TAG → DescriptionUtils.updateTagDescription`. Previously a tag URN returned `ErrUnsupportedEntityType`.

### 2. Write non-structured `customProperties` (#173, part 2)
New client methods:
- `SetCustomProperties(ctx, urn, map[string]string)` — set/overwrite keys
- `RemoveCustomProperties(ctx, urn, []string)` — delete keys

These write the legacy `customProperties` map via REST read-modify-write, preserving all other aspect fields (e.g. `glossaryTermInfo.termSource`). The per-entity aspect names were verified against the upstream DataHub PDL models; `tag` is intentionally **excluded** because `tagProperties` has no `customProperties` field.

Exposed through the reference `datahub_update` tool as `what: "custom_properties"` (`action: set|remove`) — **no new tool added**, keeping the tool count at 12.

## Bugs found during validation (also fixed here)

Live-testing against a real DataHub instance surfaced two defects that were masked by unit-test mocks. Both are broader than #173 (they affect the whole write path), so they're fixed in a separate first commit.

### Bug A — v3 writes used CREATE-only semantics
`postAspectV3` posted without `createIfNotExists=false`, so DataHub defaulted the write to **CREATE**. Any OpenAPI v3 read-modify-write (`UpdateDescription`, `AddTag`, `AddGlossaryTerm`, custom properties, …) returned **HTTP 400 — "Cannot perform CREATE since the aspect already exists"** whenever the target aspect already existed. Fixed by appending `createIfNotExists=false` (UPSERT), which both creates and updates. Verified: fresh aspect → 200, existing aspect → 200, default (no param) → 400.

### Bug B — v1 read-modify-write silently dropped existing data
`getAspect` parsed only the v3 `{"value": …}` envelope. The legacy v1 Rest.li GET returns `{"aspect": {"<FQCN>": …}}`, so on the v1 path every read-modify-write **started from an empty aspect** and silently discarded existing tags/terms/links (and 422'd on aspects with required fields). It was hidden because the unit tests mocked the `{"value": …}` shape for v1 too. Fixed the envelope parsing (tolerating a normalized flat body) and added a real-envelope test. The default `DATAHUB_API_VERSION` is v1, so this affected the default configuration.

## Validation

A throwaway program exercised the client against **live DataHub v1.6.0** (Docker quickstart), creating/cleaning up disposable entities and reading results back through an independent path. Run on **both** `DATAHUB_API_VERSION=v3` and `v1`:

| Check | v3 | v1 |
|---|---|---|
| tag description persists | ✅ | ✅ |
| glossaryTerm customProperties set + remove | ✅ | ✅ |
| domain customProperties set + remove | ✅ | ✅ |
| dataset customProperties set + remove | ✅ | ✅ |
| AddTag preserves existing tags (Bug B) | ✅ | ✅ |
| AddGlossaryTerm / AddLink preserve existing entries (Bug B) | ✅ | ✅ |

## Test coverage
- New unit tests for `SetCustomProperties`/`RemoveCustomProperties` (merge, remove, no-existing-aspect, unsupported-type, invalid URN).
- New unit tests: v1 Rest.li envelope parsing, and the `createIfNotExists=false` assertion.
- Tag-description cases added to the GraphQL update tests; updated the three tests that previously assumed tag was unsupported.
- Tool-layer tests for `what=custom_properties` dispatch, required-field validation, and error propagation.
- `make verify` passes (lint, race, coverage, patch-coverage, gosec, govulncheck, schema-check, mutation, deadcode, build).

## Compatibility
- Custom properties require an aspect that carries `customProperties`; unsupported entity types return `ErrUnsupportedCustomPropertiesEntity`.
- Works on both API versions; the v1 fix restores correct read-modify-write on the legacy default path.

## Commits
1. `fix(client): correct v3 UPSERT and v1 aspect-read envelope` — Bugs A + B
2. `feat(client): tag descriptions and custom properties (#173)` — the feature, tool exposure, docs
