### PR TITLE
fix: tag display names on read (#180) and value-as-target in datahub_update (#181)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -459,6 +459,10 @@ func (c *Client) GetEntity(ctx context.Context, urn string) (*types.Entity, erro
 						URN         string `json:"urn"`
 						Name        string `json:"name"`
 						Description string `json:"description"`
+						Properties  struct {
+							Name        string `json:"name"`
+							Description string `json:"description"`
+						} `json:"properties"`
 					} `json:"tag"`
 				} `json:"tags"`
 			} `json:"tags"`
@@ -529,12 +533,15 @@ func (c *Client) GetEntity(ctx context.Context, urn string) (*types.Entity, erro
 		})
 	}
 
-	// Parse tags
+	// Parse tags. The top-level name/description are derived from the tag's
+	// entity key (deprecated in the GraphQL schema); for tags created without an
+	// explicit id the key is a UUID, so prefer properties.name/description and
+	// fall back to the legacy fields for older servers or key-only tags.
 	for _, t := range response.Entity.Tags.Tags {
 		entity.Tags = append(entity.Tags, types.Tag{
 			URN:         t.Tag.URN,
-			Name:        t.Tag.Name,
-			Description: t.Tag.Description,
+			Name:        firstNonEmpty(t.Tag.Properties.Name, t.Tag.Name),
+			Description: firstNonEmpty(t.Tag.Properties.Description, t.Tag.Description),
 		})
 	}
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -445,6 +445,74 @@ func TestClientGetEntity(t *testing.T) {
 	}
 }
 
+// TestClientGetEntityTagPropertiesName reproduces issue #180: a tag created
+// without an explicit id has a UUID entity key, so its deprecated top-level
+// name is the UUID. GetEntity must surface properties.name/description instead,
+// while falling back to the top-level fields for legacy tags lacking properties.
+func TestClientGetEntityTagPropertiesName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]interface{}{
+			"data": map[string]interface{}{
+				"entity": map[string]interface{}{
+					"urn":  "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+					"type": "DATASET",
+					"name": "table",
+					"tags": map[string]interface{}{
+						"tags": []interface{}{
+							map[string]interface{}{
+								"tag": map[string]interface{}{
+									"urn":         "urn:li:tag:f18a56d4-c008-4c19-a1f4-b4ca776204c0",
+									"name":        "f18a56d4-c008-4c19-a1f4-b4ca776204c0",
+									"description": "",
+									"properties": map[string]interface{}{
+										"name":        "v1101-live-test",
+										"description": "live desc",
+									},
+								},
+							},
+							map[string]interface{}{
+								"tag": map[string]interface{}{
+									"urn":         "urn:li:tag:PII",
+									"name":        "PII",
+									"description": "legacy desc",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{URL: server.URL, Token: "test-token", RetryMax: 0})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	entity, err := client.GetEntity(context.Background(),
+		"urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)")
+	if err != nil {
+		t.Fatalf("GetEntity() unexpected error: %v", err)
+	}
+
+	if len(entity.Tags) != 2 {
+		t.Fatalf("GetEntity() Tags len = %d, want 2", len(entity.Tags))
+	}
+	if entity.Tags[0].Name != "v1101-live-test" {
+		t.Errorf("Tags[0].Name = %q, want v1101-live-test (from properties, not UUID)", entity.Tags[0].Name)
+	}
+	if entity.Tags[0].Description != "live desc" {
+		t.Errorf("Tags[0].Description = %q, want live desc (from properties)", entity.Tags[0].Description)
+	}
+	if entity.Tags[1].Name != "PII" {
+		t.Errorf("Tags[1].Name = %q, want PII (legacy fallback)", entity.Tags[1].Name)
+	}
+	if entity.Tags[1].Description != "legacy desc" {
+		t.Errorf("Tags[1].Description = %q, want legacy desc (fallback)", entity.Tags[1].Description)
+	}
+}
+
 func TestClientGetEntityNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(t, w, map[string]interface{}{

--- a/pkg/client/documents.go
+++ b/pkg/client/documents.go
@@ -75,6 +75,10 @@ const documentSelectionFields = `
           urn
           name
           description
+          properties {
+            name
+            description
+          }
         }
       }
     }
@@ -269,6 +273,10 @@ type documentResponse struct {
 				URN         string `json:"urn"`
 				Name        string `json:"name"`
 				Description string `json:"description"`
+				Properties  struct {
+					Name        string `json:"name"`
+					Description string `json:"description"`
+				} `json:"properties"`
 			} `json:"tag"`
 		} `json:"tags"`
 	} `json:"tags"`
@@ -345,12 +353,13 @@ func parseDocumentResponse(d *documentResponse) *types.Document {
 		})
 	}
 
-	// Parse tags
+	// Parse tags. Prefer properties.name/description over the deprecated
+	// key-derived top-level fields (UUIDs for tags created without an explicit id).
 	for _, t := range d.Tags.Tags {
 		doc.Tags = append(doc.Tags, types.Tag{
 			URN:         t.Tag.URN,
-			Name:        t.Tag.Name,
-			Description: t.Tag.Description,
+			Name:        firstNonEmpty(t.Tag.Properties.Name, t.Tag.Name),
+			Description: firstNonEmpty(t.Tag.Properties.Description, t.Tag.Description),
 		})
 	}
 

--- a/pkg/client/documents_test.go
+++ b/pkg/client/documents_test.go
@@ -34,7 +34,7 @@ func TestGetDocument(t *testing.T) {
 				},
 				"settings": {"showInGlobalContext": true},
 				"ownership": {"owners": [{"owner": {"urn": "urn:li:corpuser:alice", "username": "alice"}, "type": "DATAOWNER"}]},
-				"tags": {"tags": [{"tag": {"urn": "urn:li:tag:Production", "name": "Production"}}]},
+				"tags": {"tags": [{"tag": {"urn": "urn:li:tag:uuid-key", "name": "uuid-key", "properties": {"name": "Production"}}}]},
 				"glossaryTerms": {"terms": [{"term": {"urn": "urn:li:glossaryTerm:pii", "properties": {"name": "PII"}}}]},
 				"domain": {"domain": {"urn": "urn:li:domain:eng", "properties": {"name": "Engineering"}}}
 			}}}`,

--- a/pkg/client/queries.go
+++ b/pkg/client/queries.go
@@ -40,6 +40,10 @@ query search($input: SearchInput!) {
                 urn
                 name
                 description
+                properties {
+                  name
+                  description
+                }
               }
             }
           }
@@ -150,6 +154,10 @@ query getEntity($urn: String!) {
             urn
             name
             description
+            properties {
+              name
+              description
+            }
           }
         }
       }
@@ -276,6 +284,9 @@ query getSchema($urn: String!) {
             tag {
               urn
               name
+              properties {
+                name
+              }
             }
           }
         }
@@ -319,6 +330,9 @@ query getSchema($urn: String!) {
             tag {
               urn
               name
+              properties {
+                name
+              }
             }
           }
         }
@@ -728,6 +742,9 @@ query batchGetSchemas($urns: [String!]!) {
               tag {
                 urn
                 name
+                properties {
+                  name
+                }
               }
             }
           }
@@ -771,6 +788,9 @@ query batchGetSchemas($urns: [String!]!) {
               tag {
                 urn
                 name
+                properties {
+                  name
+                }
               }
             }
           }

--- a/pkg/client/schema_helpers.go
+++ b/pkg/client/schema_helpers.go
@@ -26,8 +26,11 @@ type rawSchemaField struct {
 	Tags           struct {
 		Tags []struct {
 			Tag struct {
-				URN  string `json:"urn"`
-				Name string `json:"name"`
+				URN        string `json:"urn"`
+				Name       string `json:"name"`
+				Properties struct {
+					Name string `json:"name"`
+				} `json:"properties"`
 			} `json:"tag"`
 		} `json:"tags"`
 	} `json:"tags"`
@@ -76,8 +79,11 @@ type rawEditableSchemaFieldInfo struct {
 	Tags struct {
 		Tags []struct {
 			Tag struct {
-				URN  string `json:"urn"`
-				Name string `json:"name"`
+				URN        string `json:"urn"`
+				Name       string `json:"name"`
+				Properties struct {
+					Name string `json:"name"`
+				} `json:"properties"`
 			} `json:"tag"`
 		} `json:"tags"`
 	} `json:"tags"`
@@ -117,10 +123,12 @@ func parseSchemaField(f rawSchemaField) types.SchemaField {
 		IsPartitionKey: f.IsPartOfKey,
 	}
 
+	// Prefer properties.name over the deprecated key-derived top-level name,
+	// which is a UUID for tags created without an explicit id.
 	for _, t := range f.Tags.Tags {
 		field.Tags = append(field.Tags, types.Tag{
 			URN:  t.Tag.URN,
-			Name: t.Tag.Name,
+			Name: firstNonEmpty(t.Tag.Properties.Name, t.Tag.Name),
 		})
 	}
 
@@ -196,7 +204,7 @@ func mergeEditableSchemaMetadata(schema *types.SchemaMetadata, edited rawEditabl
 			for _, t := range editedInfo.Tags.Tags {
 				field.Tags = append(field.Tags, types.Tag{
 					URN:  t.Tag.URN,
-					Name: t.Tag.Name,
+					Name: firstNonEmpty(t.Tag.Properties.Name, t.Tag.Name),
 				})
 			}
 		}

--- a/pkg/client/schema_helpers_test.go
+++ b/pkg/client/schema_helpers_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/txn2/mcp-datahub/pkg/types"
@@ -8,20 +9,20 @@ import (
 
 func TestParseSchemaField(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    rawSchemaField
-		expected types.SchemaField
+		name      string
+		inputJSON string
+		expected  types.SchemaField
 	}{
 		{
 			name: "basic field",
-			input: rawSchemaField{
-				FieldPath:      "customer_id",
-				Type:           "NUMBER",
-				NativeDataType: "INT64",
-				Description:    "Customer identifier",
-				Nullable:       false,
-				IsPartOfKey:    true,
-			},
+			inputJSON: `{
+				"fieldPath": "customer_id",
+				"type": "NUMBER",
+				"nativeDataType": "INT64",
+				"description": "Customer identifier",
+				"nullable": false,
+				"isPartOfKey": true
+			}`,
 			expected: types.SchemaField{
 				FieldPath:      "customer_id",
 				Type:           "NUMBER",
@@ -33,34 +34,14 @@ func TestParseSchemaField(t *testing.T) {
 		},
 		{
 			name: "field with tags",
-			input: rawSchemaField{
-				FieldPath: "email",
-				Type:      "STRING",
-				Tags: struct {
-					Tags []struct {
-						Tag struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						} `json:"tag"`
-					} `json:"tags"`
-				}{
-					Tags: []struct {
-						Tag struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						} `json:"tag"`
-					}{
-						{Tag: struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						}{URN: "urn:li:tag:pii", Name: "pii"}},
-						{Tag: struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						}{URN: "urn:li:tag:sensitive", Name: "sensitive"}},
-					},
-				},
-			},
+			inputJSON: `{
+				"fieldPath": "email",
+				"type": "STRING",
+				"tags": {"tags": [
+					{"tag": {"urn": "urn:li:tag:pii", "name": "pii"}},
+					{"tag": {"urn": "urn:li:tag:sensitive", "name": "sensitive"}}
+				]}
+			}`,
 			expected: types.SchemaField{
 				FieldPath: "email",
 				Type:      "STRING",
@@ -71,31 +52,36 @@ func TestParseSchemaField(t *testing.T) {
 			},
 		},
 		{
-			name: "field with glossary terms",
-			input: rawSchemaField{
-				FieldPath: "revenue",
-				Type:      "NUMBER",
-				GlossaryTerms: struct {
-					Terms []struct {
-						Term struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						} `json:"term"`
-					} `json:"terms"`
-				}{
-					Terms: []struct {
-						Term struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						} `json:"term"`
-					}{
-						{Term: struct {
-							URN  string `json:"urn"`
-							Name string `json:"name"`
-						}{URN: "urn:li:glossaryTerm:Finance.Revenue", Name: "Revenue"}},
-					},
+			// A UUID-keyed tag surfaces its properties.name, not the key-derived
+			// top-level name; a legacy tag without properties falls back.
+			name: "field with UUID tag and legacy fallback",
+			inputJSON: `{
+				"fieldPath": "ssn",
+				"type": "STRING",
+				"tags": {"tags": [
+					{"tag": {"urn": "urn:li:tag:f18a56d4", "name": "f18a56d4",
+						"properties": {"name": "v1101-live-test"}}},
+					{"tag": {"urn": "urn:li:tag:PII", "name": "PII"}}
+				]}
+			}`,
+			expected: types.SchemaField{
+				FieldPath: "ssn",
+				Type:      "STRING",
+				Tags: []types.Tag{
+					{URN: "urn:li:tag:f18a56d4", Name: "v1101-live-test"},
+					{URN: "urn:li:tag:PII", Name: "PII"},
 				},
 			},
+		},
+		{
+			name: "field with glossary terms",
+			inputJSON: `{
+				"fieldPath": "revenue",
+				"type": "NUMBER",
+				"glossaryTerms": {"terms": [
+					{"term": {"urn": "urn:li:glossaryTerm:Finance.Revenue", "name": "Revenue"}}
+				]}
+			}`,
 			expected: types.SchemaField{
 				FieldPath: "revenue",
 				Type:      "NUMBER",
@@ -108,7 +94,11 @@ func TestParseSchemaField(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := parseSchemaField(tc.input)
+			var input rawSchemaField
+			if err := json.Unmarshal([]byte(tc.inputJSON), &input); err != nil {
+				t.Fatalf("unmarshal input: %v", err)
+			}
+			result := parseSchemaField(input)
 
 			if result.FieldPath != tc.expected.FieldPath {
 				t.Errorf("FieldPath = %s, want %s", result.FieldPath, tc.expected.FieldPath)
@@ -348,17 +338,13 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 	tests := []struct {
 		name           string
 		schema         *types.SchemaMetadata
-		edited         rawEditableSchemaMetadata
+		editedJSON     string
 		expectedFields []types.SchemaField
 	}{
 		{
-			name:   "nil schema does not panic",
-			schema: nil,
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{FieldPath: "field1", Description: "edited"},
-				},
-			},
+			name:           "nil schema does not panic",
+			schema:         nil,
+			editedJSON:     `{"editableSchemaFieldInfo":[{"fieldPath":"field1","description":"edited"}]}`,
 			expectedFields: nil,
 		},
 		{
@@ -368,7 +354,7 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "field1", Description: "original"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{},
+			editedJSON: `{}`,
 			expectedFields: []types.SchemaField{
 				{FieldPath: "field1", Description: "original"},
 			},
@@ -380,11 +366,7 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "field1", Description: "original description"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{FieldPath: "field1", Description: "UI edited description"},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"field1","description":"UI edited description"}]}`,
 			expectedFields: []types.SchemaField{
 				{FieldPath: "field1", Description: "UI edited description"},
 			},
@@ -396,11 +378,7 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "field1", Description: "original description"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{FieldPath: "field1", Description: ""},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"field1","description":""}]}`,
 			expectedFields: []types.SchemaField{
 				{FieldPath: "field1", Description: "original description"},
 			},
@@ -417,33 +395,10 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{
-						FieldPath: "revenue",
-						GlossaryTerms: struct {
-							Terms []struct {
-								Term struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"term"`
-							} `json:"terms"`
-						}{
-							Terms: []struct {
-								Term struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"term"`
-							}{
-								{Term: struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								}{URN: "urn:li:glossaryTerm:ui_added", Name: "UI Added Term"}},
-							},
-						},
-					},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"revenue",
+				"glossaryTerms":{"terms":[
+					{"term":{"urn":"urn:li:glossaryTerm:ui_added","name":"UI Added Term"}}
+				]}}]}`,
 			expectedFields: []types.SchemaField{
 				{
 					FieldPath: "revenue",
@@ -465,33 +420,10 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{
-						FieldPath: "email",
-						Tags: struct {
-							Tags []struct {
-								Tag struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"tag"`
-							} `json:"tags"`
-						}{
-							Tags: []struct {
-								Tag struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"tag"`
-							}{
-								{Tag: struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								}{URN: "urn:li:tag:pii", Name: "PII"}},
-							},
-						},
-					},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"email",
+				"tags":{"tags":[
+					{"tag":{"urn":"urn:li:tag:pii","name":"PII"}}
+				]}}]}`,
 			expectedFields: []types.SchemaField{
 				{
 					FieldPath: "email",
@@ -513,15 +445,7 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{
-						FieldPath:   "revenue",
-						Description: "Edited description only",
-						// No glossaryTerms - should preserve ingested ones
-					},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"revenue","description":"Edited description only"}]}`,
 			expectedFields: []types.SchemaField{
 				{
 					FieldPath:   "revenue",
@@ -539,11 +463,7 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "existing_field", Description: "original"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{FieldPath: "nonexistent_field", Description: "should be ignored"},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"nonexistent_field","description":"should be ignored"}]}`,
 			expectedFields: []types.SchemaField{
 				{FieldPath: "existing_field", Description: "original"},
 			},
@@ -557,12 +477,10 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "field3", Description: "desc3"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{FieldPath: "field1", Description: "edited1"},
-					{FieldPath: "field3", Description: "edited3"},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[
+				{"fieldPath":"field1","description":"edited1"},
+				{"fieldPath":"field3","description":"edited3"}
+			]}`,
 			expectedFields: []types.SchemaField{
 				{FieldPath: "field1", Description: "edited1"},
 				{FieldPath: "field2", Description: "desc2"},
@@ -576,33 +494,10 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 					{FieldPath: "field1"},
 				},
 			},
-			edited: rawEditableSchemaMetadata{
-				EditableSchemaFieldInfo: []rawEditableSchemaFieldInfo{
-					{
-						FieldPath: "field1",
-						GlossaryTerms: struct {
-							Terms []struct {
-								Term struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"term"`
-							} `json:"terms"`
-						}{
-							Terms: []struct {
-								Term struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								} `json:"term"`
-							}{
-								{Term: struct {
-									URN  string `json:"urn"`
-									Name string `json:"name"`
-								}{URN: "urn:li:glossaryTerm:new", Name: "New Term"}},
-							},
-						},
-					},
-				},
-			},
+			editedJSON: `{"editableSchemaFieldInfo":[{"fieldPath":"field1",
+				"glossaryTerms":{"terms":[
+					{"term":{"urn":"urn:li:glossaryTerm:new","name":"New Term"}}
+				]}}]}`,
 			expectedFields: []types.SchemaField{
 				{
 					FieldPath: "field1",
@@ -616,7 +511,11 @@ func TestMergeEditableSchemaMetadata(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mergeEditableSchemaMetadata(tc.schema, tc.edited)
+			var edited rawEditableSchemaMetadata
+			if err := json.Unmarshal([]byte(tc.editedJSON), &edited); err != nil {
+				t.Fatalf("unmarshal edited: %v", err)
+			}
+			mergeEditableSchemaMetadata(tc.schema, edited)
 
 			if tc.schema == nil {
 				return

--- a/pkg/client/search_helpers.go
+++ b/pkg/client/search_helpers.go
@@ -42,6 +42,10 @@ type searchResultItem struct {
 					URN         string `json:"urn"`
 					Name        string `json:"name"`
 					Description string `json:"description"`
+					Properties  struct {
+						Name        string `json:"name"`
+						Description string `json:"description"`
+					} `json:"properties"`
 				} `json:"tag"`
 			} `json:"tags"`
 		} `json:"tags"`
@@ -105,11 +109,13 @@ func parseSearchResult(sr searchResultItem) types.SearchEntity {
 		})
 	}
 
+	// Prefer properties.name/description over the deprecated key-derived
+	// top-level fields, which are UUIDs for tags created without an explicit id.
 	for _, t := range sr.Entity.Tags.Tags {
 		entity.Tags = append(entity.Tags, types.Tag{
 			URN:         t.Tag.URN,
-			Name:        t.Tag.Name,
-			Description: t.Tag.Description,
+			Name:        firstNonEmpty(t.Tag.Properties.Name, t.Tag.Name),
+			Description: firstNonEmpty(t.Tag.Properties.Description, t.Tag.Description),
 		})
 	}
 

--- a/pkg/client/search_helpers_test.go
+++ b/pkg/client/search_helpers_test.go
@@ -1,6 +1,9 @@
 package client
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestParseSearchResult_DocumentEntity(t *testing.T) {
 	sr := searchResultItem{}
@@ -78,18 +81,11 @@ func TestParseSearchResult_NonDocumentEntity(t *testing.T) {
 			Type: "DATAOWNER",
 		},
 	}
-	sr.Entity.Tags.Tags = []struct {
-		Tag struct {
-			URN         string `json:"urn"`
-			Name        string `json:"name"`
-			Description string `json:"description"`
-		} `json:"tag"`
-	}{
-		{Tag: struct {
-			URN         string `json:"urn"`
-			Name        string `json:"name"`
-			Description string `json:"description"`
-		}{URN: "urn:li:tag:prod", Name: "prod"}},
+	if err := json.Unmarshal(
+		[]byte(`{"tags":[{"tag":{"urn":"urn:li:tag:prod","name":"prod"}}]}`),
+		&sr.Entity.Tags,
+	); err != nil {
+		t.Fatalf("unmarshal tags: %v", err)
 	}
 	sr.Entity.Domain.Domain.URN = "urn:li:domain:eng"
 	sr.Entity.Domain.Domain.Properties.Name = "Engineering"
@@ -129,5 +125,40 @@ func TestParseSearchResult_PropertiesOverride(t *testing.T) {
 	}
 	if entity.Description != "Personally Identifiable Information" {
 		t.Errorf("Description = %q, want from properties", entity.Description)
+	}
+}
+
+// TestParseSearchResult_TagPropertiesName verifies a tag whose entity key is a
+// UUID surfaces its properties.name/description rather than the deprecated
+// key-derived top-level fields, and that legacy tags without properties fall
+// back to the top-level fields.
+func TestParseSearchResult_TagPropertiesName(t *testing.T) {
+	sr := searchResultItem{}
+	sr.Entity.URN = "urn:li:dataset:test"
+	sr.Entity.Type = "DATASET"
+	if err := json.Unmarshal([]byte(`{"tags":[
+		{"tag":{"urn":"urn:li:tag:f18a56d4","name":"f18a56d4","description":"",
+			"properties":{"name":"v1101-live-test","description":"live desc"}}},
+		{"tag":{"urn":"urn:li:tag:PII","name":"PII","description":"legacy desc"}}
+	]}`), &sr.Entity.Tags); err != nil {
+		t.Fatalf("unmarshal tags: %v", err)
+	}
+
+	entity := parseSearchResult(sr)
+
+	if len(entity.Tags) != 2 {
+		t.Fatalf("Tags len = %d, want 2", len(entity.Tags))
+	}
+	if entity.Tags[0].Name != "v1101-live-test" {
+		t.Errorf("Tags[0].Name = %q, want v1101-live-test (from properties)", entity.Tags[0].Name)
+	}
+	if entity.Tags[0].Description != "live desc" {
+		t.Errorf("Tags[0].Description = %q, want live desc (from properties)", entity.Tags[0].Description)
+	}
+	if entity.Tags[1].Name != "PII" {
+		t.Errorf("Tags[1].Name = %q, want PII (legacy fallback)", entity.Tags[1].Name)
+	}
+	if entity.Tags[1].Description != "legacy desc" {
+		t.Errorf("Tags[1].Description = %q, want legacy desc (fallback)", entity.Tags[1].Description)
 	}
 }

--- a/pkg/tools/errors.go
+++ b/pkg/tools/errors.go
@@ -37,6 +37,13 @@ func errInvalidAction(got string, valid ...string) error {
 	return fmt.Errorf("action must be '%s', got '%s'", strings.Join(valid, "' or '"), got)
 }
 
+// errTargetConflict returns an error when target_urn and value both carry a
+// URN for an association operation but disagree, rather than silently
+// preferring one.
+func errTargetConflict(targetURN, value string) error {
+	return fmt.Errorf("target_urn (%s) and value (%s) differ; set only target_urn", targetURN, value)
+}
+
 // JSONResult creates a JSON result for tool responses.
 func JSONResult(v any) (*mcp.CallToolResult, error) {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/pkg/tools/write_update.go
+++ b/pkg/tools/write_update.go
@@ -21,10 +21,12 @@ type UpdateInput struct {
 	URN string `json:"urn" jsonschema_description:"URN of the entity to update"`
 
 	// Common value field
-	Value string `json:"value,omitempty" jsonschema_description:"New value (description text, status, sub_type, label, message, etc.)"`
+	//nolint:lll // struct tag cannot be split
+	Value string `json:"value,omitempty" jsonschema_description:"New value (description text, status, sub_type, label, message, etc.). NOT the tag/term/owner/domain URN for add/remove/set: use target_urn (a URN passed here alone is accepted as a fallback)"`
 
 	// Target URN for add/remove operations (tag, glossary_term, owner, domain)
-	TargetURN string `json:"target_urn,omitempty" jsonschema_description:"Target URN (tag, glossary term, owner, or domain URN)"`
+	//nolint:lll // struct tag cannot be split
+	TargetURN string `json:"target_urn,omitempty" jsonschema_description:"Target tag, glossary term, owner, or domain URN. Required for tag/glossary_term/owner add and remove, and domain set"`
 
 	// Link-specific fields
 	URL string `json:"url,omitempty" jsonschema_description:"URL for link operations"`

--- a/pkg/tools/write_update_handlers.go
+++ b/pkg/tools/write_update_handlers.go
@@ -14,6 +14,23 @@ const (
 	actionSet    = "set"
 )
 
+// resolveTargetURN determines the target of an association operation (tag,
+// glossary_term, owner, domain add/remove/set). target_urn is authoritative,
+// but a lone value carrying the URN is accepted so agents that pass the URN in
+// the generic value field succeed on the first attempt. When both are set they
+// must agree; a genuine disagreement is rejected rather than silently
+// preferring one. Returns "" when neither is set so callers surface the usual
+// "target_urn parameter is required" error.
+func resolveTargetURN(input UpdateInput) (string, error) {
+	if input.TargetURN != "" && input.Value != "" && input.TargetURN != input.Value {
+		return "", errTargetConflict(input.TargetURN, input.Value)
+	}
+	if input.TargetURN != "" {
+		return input.TargetURN, nil
+	}
+	return input.Value, nil
+}
+
 func (t *Toolkit) handleUpdateDescription(
 	ctx context.Context, c DataHubClient, input UpdateInput,
 ) (UpdateOutput, error) {
@@ -47,20 +64,24 @@ func (t *Toolkit) handleUpdateTag(
 	if action == "" {
 		return UpdateOutput{}, errRequired("action (add or remove)")
 	}
-	if input.TargetURN == "" {
+	target, err := resolveTargetURN(input)
+	if err != nil {
+		return UpdateOutput{}, err
+	}
+	if target == "" {
 		return UpdateOutput{}, errRequired("target_urn")
 	}
 	switch action {
 	case actionAdd:
-		if err := c.AddTag(ctx, input.URN, input.TargetURN); err != nil {
+		if err := c.AddTag(ctx, input.URN, target); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "tag", Action: "added", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "tag", Action: "added", TargetURN: target}, nil
 	case actionRemove:
-		if err := c.RemoveTag(ctx, input.URN, input.TargetURN); err != nil {
+		if err := c.RemoveTag(ctx, input.URN, target); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "tag", Action: "removed", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "tag", Action: "removed", TargetURN: target}, nil
 	default:
 		return UpdateOutput{}, errInvalidAction(action, "add", "remove")
 	}
@@ -72,20 +93,24 @@ func (t *Toolkit) handleUpdateGlossaryTerm(
 	if action == "" {
 		return UpdateOutput{}, errRequired("action (add or remove)")
 	}
-	if input.TargetURN == "" {
+	target, err := resolveTargetURN(input)
+	if err != nil {
+		return UpdateOutput{}, err
+	}
+	if target == "" {
 		return UpdateOutput{}, errRequired("target_urn")
 	}
 	switch action {
 	case actionAdd:
-		if err := c.AddGlossaryTerm(ctx, input.URN, input.TargetURN); err != nil {
+		if err := c.AddGlossaryTerm(ctx, input.URN, target); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "glossary_term", Action: "added", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "glossary_term", Action: "added", TargetURN: target}, nil
 	case actionRemove:
-		if err := c.RemoveGlossaryTerm(ctx, input.URN, input.TargetURN); err != nil {
+		if err := c.RemoveGlossaryTerm(ctx, input.URN, target); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "glossary_term", Action: "removed", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "glossary_term", Action: "removed", TargetURN: target}, nil
 	default:
 		return UpdateOutput{}, errInvalidAction(action, "add", "remove")
 	}
@@ -122,7 +147,11 @@ func (t *Toolkit) handleUpdateOwner(
 	if action == "" {
 		return UpdateOutput{}, errRequired("action (add or remove)")
 	}
-	if input.TargetURN == "" {
+	target, err := resolveTargetURN(input)
+	if err != nil {
+		return UpdateOutput{}, err
+	}
+	if target == "" {
 		return UpdateOutput{}, errRequired("target_urn (owner URN)")
 	}
 	switch action {
@@ -131,15 +160,15 @@ func (t *Toolkit) handleUpdateOwner(
 		if ownerType == "" {
 			ownerType = "TECHNICAL_OWNER"
 		}
-		if err := c.AddOwner(ctx, input.URN, input.TargetURN, ownerType); err != nil {
+		if err := c.AddOwner(ctx, input.URN, target, ownerType); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "owner", Action: "added", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "owner", Action: "added", TargetURN: target}, nil
 	case actionRemove:
-		if err := c.RemoveOwner(ctx, input.URN, input.TargetURN); err != nil {
+		if err := c.RemoveOwner(ctx, input.URN, target); err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "owner", Action: "removed", TargetURN: input.TargetURN}, nil
+		return UpdateOutput{URN: input.URN, What: "owner", Action: "removed", TargetURN: target}, nil
 	default:
 		return UpdateOutput{}, errInvalidAction(action, "add", "remove")
 	}
@@ -153,13 +182,17 @@ func (t *Toolkit) handleUpdateDomain(
 	}
 	switch action {
 	case actionSet:
-		if input.TargetURN == "" {
-			return UpdateOutput{}, errRequired("target_urn (domain URN)")
-		}
-		if err := c.SetDomain(ctx, input.URN, input.TargetURN); err != nil {
+		target, err := resolveTargetURN(input)
+		if err != nil {
 			return UpdateOutput{}, err
 		}
-		return UpdateOutput{URN: input.URN, What: "domain", Action: "set", TargetURN: input.TargetURN}, nil
+		if target == "" {
+			return UpdateOutput{}, errRequired("target_urn (domain URN)")
+		}
+		if err := c.SetDomain(ctx, input.URN, target); err != nil {
+			return UpdateOutput{}, err
+		}
+		return UpdateOutput{URN: input.URN, What: "domain", Action: "set", TargetURN: target}, nil
 	case actionRemove:
 		if err := c.UnsetDomain(ctx, input.URN); err != nil {
 			return UpdateOutput{}, err

--- a/pkg/tools/write_update_test.go
+++ b/pkg/tools/write_update_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -148,6 +149,33 @@ func TestHandleUpdate_MetadataOperations(t *testing.T) {
 			"tag_remove",
 			UpdateInput{What: "tag", Action: "remove", URN: urn, TargetURN: "urn:li:tag:PII"},
 			"tag", "removed", "urn:li:tag:PII",
+		},
+		{
+			// Issue #181: a lone value carrying the tag URN is accepted as target.
+			"tag_add_via_value",
+			UpdateInput{What: "tag", Action: "add", URN: urn, Value: "urn:li:tag:PII"},
+			"tag", "added", "urn:li:tag:PII",
+		},
+		{
+			// target_urn and value agree: not a conflict.
+			"tag_add_both_equal",
+			UpdateInput{What: "tag", Action: "add", URN: urn, TargetURN: "urn:li:tag:PII", Value: "urn:li:tag:PII"},
+			"tag", "added", "urn:li:tag:PII",
+		},
+		{
+			"glossary_term_add_via_value",
+			UpdateInput{What: "glossary_term", Action: "add", URN: urn, Value: "urn:li:glossaryTerm:X"},
+			"glossary_term", "added", "urn:li:glossaryTerm:X",
+		},
+		{
+			"owner_add_via_value",
+			UpdateInput{What: "owner", Action: "add", URN: urn, Value: "urn:li:corpuser:user1"},
+			"owner", "added", "urn:li:corpuser:user1",
+		},
+		{
+			"domain_set_via_value",
+			UpdateInput{What: "domain", Action: "set", URN: urn, Value: "urn:li:domain:eng"},
+			"domain", "set", "urn:li:domain:eng",
 		},
 		{
 			"glossary_term_add",
@@ -331,6 +359,65 @@ func TestHandleUpdate_MissingRequiredFields(t *testing.T) {
 				t.Errorf("expected error for %s", tt.name)
 			}
 		})
+	}
+}
+
+// TestHandleUpdate_TargetURNAndValueConflict verifies that when target_urn and
+// value both carry a URN but disagree, the update is rejected rather than
+// silently preferring one (issue #181).
+func TestHandleUpdate_TargetURNAndValueConflict(t *testing.T) {
+	toolkit := NewToolkit(&mockClient{}, Config{WriteEnabled: true})
+	urn := "urn:li:dataset:(urn:li:dataPlatform:hive,db.table,PROD)"
+
+	tests := []struct {
+		name  string
+		input UpdateInput
+	}{
+		{"tag", UpdateInput{
+			What: "tag", Action: "add", URN: urn,
+			TargetURN: "urn:li:tag:PII", Value: "urn:li:tag:Financial",
+		}},
+		{"glossary_term", UpdateInput{
+			What: "glossary_term", Action: "add", URN: urn,
+			TargetURN: "urn:li:glossaryTerm:X", Value: "urn:li:glossaryTerm:Y",
+		}},
+		{"owner", UpdateInput{
+			What: "owner", Action: "add", URN: urn,
+			TargetURN: "urn:li:corpuser:a", Value: "urn:li:corpuser:b",
+		}},
+		{"domain", UpdateInput{
+			What: "domain", Action: "set", URN: urn,
+			TargetURN: "urn:li:domain:eng", Value: "urn:li:domain:sales",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, _ := toolkit.handleUpdate(context.Background(), nil, tt.input)
+			if !result.IsError {
+				t.Fatalf("expected error for conflicting target_urn/value")
+			}
+			msg := result.Content[0].(*mcp.TextContent).Text
+			if !strings.Contains(msg, "target_urn") || !strings.Contains(msg, "differ") {
+				t.Errorf("error = %q, want it to mention target_urn and differ", msg)
+			}
+		})
+	}
+}
+
+// TestHandleUpdate_NeitherTargetNorValueNamesTargetURN verifies the missing-target
+// error still names target_urn (not value) when both are absent (issue #181).
+func TestHandleUpdate_NeitherTargetNorValueNamesTargetURN(t *testing.T) {
+	toolkit := NewToolkit(&mockClient{}, Config{WriteEnabled: true})
+	urn := "urn:li:dataset:(urn:li:dataPlatform:hive,db.table,PROD)"
+
+	result, _, _ := toolkit.handleUpdate(context.Background(), nil,
+		UpdateInput{What: "tag", Action: "add", URN: urn})
+	if !result.IsError {
+		t.Fatal("expected error when neither target_urn nor value is set")
+	}
+	if msg := result.Content[0].(*mcp.TextContent).Text; !strings.Contains(msg, "target_urn") {
+		t.Errorf("error = %q, want it to name target_urn", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses the two open tickets:

- **Fixes #180** — tags created through `datahub_create` rendered as UUIDs on every subsequent read (bug).
- **Closes #181** — `datahub_update` now accepts `value` as the target for tag/term/owner/domain add-remove, and the schema says so (enhancement).

Two focused commits, one per issue, split cleanly by package (`pkg/client` for #180, `pkg/tools` for #181).

---

## #180 — created tags render as UUIDs

### Root cause
DataHub's `createTag` mutation generates a **UUID entity key** when the input carries no explicit `id`; the display name lands in the `tagProperties.name` aspect. On the read side, the entity-query tag fragments selected only the tag's top-level `name`, which DataHub derives from the entity key (deprecated in the GraphQL schema in favor of `properties.name`). For a UUID-keyed tag, that field **is** the UUID.

Effect: seeded tags with human-readable keys (`urn:li:tag:PII`) render fine, so the bug only bit tags created through this toolkit's own create path — the create→attach→read round trip showed a UUID where the user's chosen name should be.

### Fix (read-side)
- Extended **every** tag fragment to also select `properties { name description }`:
  - `SearchQuery`, `GetEntityQuery`, the document query, and the field-level tags in `GetSchemaQuery` + `BatchGetSchemasQuery`.
- Updated the parse structs/loops in `client.go`, `search_helpers.go`, `documents.go`, `schema_helpers.go` to prefer `properties.name`/`properties.description`, **falling back** to the legacy top-level fields for older servers and key-named tags.

The optional write-side change (passing `id` to `CreateTag` for human-readable URNs) was **intentionally not done** — the issue flagged it as cosmetic and "discuss before doing." The read-side fix alone resolves the observed defect. Happy to follow up if we want readable tag URNs too.

### Tests
- `TestClientGetEntityTagPropertiesName`: replicates the issue exactly — a UUID-keyed tag with `properties.name` set plus a legacy tag without properties; asserts the first surfaces its display name and description, the second falls back.
- Added the UUID-with-fallback case to the search, schema-field, and document read paths.
- Rewrote the brittle inline anonymous-struct test fixtures to unmarshal from JSON (removes the type-duplication that made these tests fragile).

---

## #181 — accept `value` as the association target

### Problem
`datahub_update` with `what=tag, action=add` required the tag URN in `target_urn`, but the schema also exposed a generic `value` field. Agents picked `value` often enough to matter — a first attempt of `datahub_update(what=tag, action=add, urn=<dataset>, value=<tag urn>)` failed with `target_urn parameter is required` and succeeded only on retry. The failed round trip is avoidable.

### Fix
- Added `resolveTargetURN()` and wired it into the **tag, glossary_term, owner, and domain(set)** handlers:
  - `target_urn` stays authoritative.
  - A lone `value` carrying a URN is accepted.
  - Both set and equal → succeeds.
  - Both set and **different** → rejected with a clear message (rather than silently preferring one).
  - Neither set → still errors naming `target_urn`.
- Tightened the schema descriptions so first attempts succeed more often:
  - `value`: states it is **NOT** the tag/term/owner/domain URN for add/remove/set (with the note that a URN passed here alone is accepted as a fallback).
  - `target_urn`: states which what/action combinations require it.

### Tests
- add-via-`value` success for all four association types; both-set-and-equal success.
- both-set-and-different rejection (asserts the error names `target_urn` and "differ").
- neither-set error still names `target_urn` (not `value`).

---

## Verification

`make verify` passes cleanly (unit tests with `-race`, lint, security, schema-check against upstream DataHub schema, coverage, patch-coverage, mutation, build). The `deadcode` lines are the expected exported-library-API noise and are non-blocking.

- `make schema-check` confirms `properties { name description }` is valid on the `Tag` type across all modified queries.
