### PR TITLE
fix(tools): resolve description text from value or description

### DIFF
--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -707,12 +707,12 @@ Update metadata on an existing entity.
 | `what` | string | Yes | What to update (see table below) |
 | `action` | string | Varies | `add`/`remove` (required for tag, glossary_term, link, owner); `set`/`remove` (domain, structured_properties, custom_properties, default: set); not used for other what values |
 | `urn` | string | Yes | Entity URN |
-| `value` | string | No | New value (description, status, label, message) |
+| `value` | string | No | New value: the description text for `description` and `column_description`, otherwise status, label, message |
 | `target_urn` | string | No | Target URN for add/remove (tag, glossary term, owner, domain) |
 | `url` | string | No | URL for link operations |
 | `field_path` | string | No | Schema field path (column_description) |
 | `name` | string | No | Updated name (query, incident, structured_property) |
-| `description` | string | No | Updated description |
+| `description` | string | No | Updated description (query, incident, structured_property). For `description` and `column_description` the text belongs in `value`; it is accepted here too, and one of the two must carry it |
 | `ownership_type` | string | No | Ownership type, e.g. TECHNICAL_OWNER (owner add only) |
 | `properties` | object[] | No | Structured property values to set (structured_properties) |
 | `property_urns` | string[] | No | Property URNs to remove (structured_properties) |
@@ -735,8 +735,8 @@ Update metadata on an existing entity.
 
 | what | action | Description |
 |------|--------|-------------|
-| `description` | _(not used)_ | Set entity description (also edits tag and glossaryTerm descriptions) |
-| `column_description` | _(not used)_ | Set schema field description |
+| `description` | _(not used)_ | Set entity description from `value` (also edits tag and glossaryTerm descriptions) |
+| `column_description` | _(not used)_ | Set schema field description from `value` |
 | `tag` | **required**: add/remove | Add or remove a tag |
 | `glossary_term` | **required**: add/remove | Add or remove a glossary term |
 | `link` | **required**: add/remove | Add or remove a link |

--- a/pkg/tools/errors.go
+++ b/pkg/tools/errors.go
@@ -44,6 +44,13 @@ func errTargetConflict(targetURN, value string) error {
 	return fmt.Errorf("target_urn (%s) and value (%s) differ; set only target_urn", targetURN, value)
 }
 
+// errDescriptionConflict returns an error when value and description both carry
+// description text for a description update but disagree, rather than silently
+// preferring one.
+func errDescriptionConflict(value, description string) error {
+	return fmt.Errorf("value (%s) and description (%s) differ; set only value", value, description)
+}
+
 // JSONResult creates a JSON result for tool responses.
 func JSONResult(v any) (*mcp.CallToolResult, error) {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/pkg/tools/write_update.go
+++ b/pkg/tools/write_update.go
@@ -22,7 +22,7 @@ type UpdateInput struct {
 
 	// Common value field
 	//nolint:lll // struct tag cannot be split
-	Value string `json:"value,omitempty" jsonschema_description:"New value (description text, status, sub_type, label, message, etc.). NOT the tag/term/owner/domain URN for add/remove/set: use target_urn (a URN passed here alone is accepted as a fallback)"`
+	Value string `json:"value,omitempty" jsonschema_description:"New value (description text for what=description and what=column_description, status, sub_type, label, message, etc.). NOT the tag/term/owner/domain URN for add/remove/set: use target_urn (a URN passed here alone is accepted as a fallback)"`
 
 	// Target URN for add/remove operations (tag, glossary_term, owner, domain)
 	//nolint:lll // struct tag cannot be split
@@ -48,8 +48,9 @@ type UpdateInput struct {
 	PropertyKeys []string `json:"property_keys,omitempty" jsonschema_description:"Legacy customProperties keys to remove (custom_properties, action=remove)"`
 
 	// Query-specific
-	Name        string   `json:"name,omitempty" jsonschema_description:"Updated name (query, incident, structured_property)"`
-	Description string   `json:"description,omitempty" jsonschema_description:"Updated description"`
+	Name string `json:"name,omitempty" jsonschema_description:"Updated name (query, incident, structured_property)"`
+	//nolint:lll // struct tag cannot be split
+	Description string   `json:"description,omitempty" jsonschema_description:"Updated description (query, incident, structured_property). For what=description and what=column_description the text belongs in value; it is accepted here too, and one of the two must carry it"`
 	Language    string   `json:"language,omitempty" jsonschema_description:"Query language (query only)"`
 	DatasetURNs []string `json:"dataset_urns,omitempty" jsonschema_description:"Dataset URNs (query, data_contract)"`
 

--- a/pkg/tools/write_update_description_test.go
+++ b/pkg/tools/write_update_description_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const descTestURN = "urn:li:dataset:(urn:li:dataPlatform:hive,db.table,PROD)"
+
+// resultText returns the text of a tool result's first content block.
+func resultText(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return text.Text
+}
+
+// recordingDescClient captures the description text that reaches the client, so a
+// test can tell an empty write apart from no write at all.
+type recordingDescClient struct {
+	mockClient
+	called bool
+	got    string
+}
+
+func newRecordingDescClient() *recordingDescClient {
+	rec := &recordingDescClient{}
+	rec.updateDescriptionFunc = func(_ context.Context, _, description string) error {
+		rec.called = true
+		rec.got = description
+		return nil
+	}
+	rec.updateColumnDescriptionFunc = func(_ context.Context, _, _, description string) error {
+		rec.called = true
+		rec.got = description
+		return nil
+	}
+	return rec
+}
+
+// TestHandleUpdate_DescriptionFromDescriptionField covers the text arriving in
+// `description` rather than `value`. `description` is a real field for other what
+// values, so the schema accepts it here; reading only `value` wrote an empty
+// description - erasing any description the target carried - and still answered
+// "updated" (#194).
+func TestHandleUpdate_DescriptionFromDescriptionField(t *testing.T) {
+	tests := []struct {
+		name  string
+		input UpdateInput
+	}{
+		{
+			"entity description",
+			UpdateInput{What: "description", URN: descTestURN, Description: "Gross margin before returns"},
+		},
+		{
+			"column description",
+			UpdateInput{
+				What: "column_description", URN: descTestURN, FieldPath: "amount",
+				Description: "Gross margin before returns",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newRecordingDescClient()
+			toolkit := NewToolkit(rec, Config{WriteEnabled: true})
+
+			result, _, _ := toolkit.handleUpdate(context.Background(), nil, tt.input)
+
+			if result.IsError {
+				t.Fatalf("expected success, got error result")
+			}
+			if !rec.called {
+				t.Fatal("client was never called")
+			}
+			if rec.got != "Gross margin before returns" {
+				t.Errorf("client received %q, want the description text", rec.got)
+			}
+		})
+	}
+}
+
+// TestHandleUpdate_DescriptionValueWins keeps `value` authoritative when both
+// fields carry the same text.
+func TestHandleUpdate_DescriptionValueWins(t *testing.T) {
+	rec := newRecordingDescClient()
+	toolkit := NewToolkit(rec, Config{WriteEnabled: true})
+
+	result, _, _ := toolkit.handleUpdate(context.Background(), nil, UpdateInput{
+		What: "description", URN: descTestURN, Value: "Same text", Description: "Same text",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error result")
+	}
+	if rec.got != "Same text" {
+		t.Errorf("client received %q, want %q", rec.got, "Same text")
+	}
+}
+
+// TestHandleUpdate_DescriptionConflict rejects a genuine disagreement rather than
+// silently picking one of the two.
+func TestHandleUpdate_DescriptionConflict(t *testing.T) {
+	rec := newRecordingDescClient()
+	toolkit := NewToolkit(rec, Config{WriteEnabled: true})
+
+	result, _, _ := toolkit.handleUpdate(context.Background(), nil, UpdateInput{
+		What: "description", URN: descTestURN, Value: "One text", Description: "Other text",
+	})
+
+	if !result.IsError {
+		t.Fatal("expected an error result when value and description differ")
+	}
+	if rec.called {
+		t.Error("client must not be called when the two fields conflict")
+	}
+}
+
+// TestHandleUpdate_DescriptionRequiresText refuses a description update carrying
+// no text at all, instead of writing an empty description and reporting "updated".
+func TestHandleUpdate_DescriptionRequiresText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input UpdateInput
+	}{
+		{"entity description", UpdateInput{What: "description", URN: descTestURN}},
+		{"column description", UpdateInput{What: "column_description", URN: descTestURN, FieldPath: "amount"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newRecordingDescClient()
+			toolkit := NewToolkit(rec, Config{WriteEnabled: true})
+
+			result, _, _ := toolkit.handleUpdate(context.Background(), nil, tt.input)
+
+			if !result.IsError {
+				t.Fatal("expected an error result when no description text is given")
+			}
+			if rec.called {
+				t.Error("client must not be called when no description text is given")
+			}
+			if text := resultText(result); !strings.Contains(text, "value") {
+				t.Errorf("error should name the value parameter, got %q", text)
+			}
+		})
+	}
+}
+
+// TestHandleUpdate_ColumnDescriptionRequiresFieldPathFirst keeps the missing
+// field_path error ahead of the description check, so the caller is told the more
+// specific problem.
+func TestHandleUpdate_ColumnDescriptionRequiresFieldPathFirst(t *testing.T) {
+	rec := newRecordingDescClient()
+	toolkit := NewToolkit(rec, Config{WriteEnabled: true})
+
+	result, _, _ := toolkit.handleUpdate(context.Background(), nil, UpdateInput{
+		What: "column_description", URN: descTestURN, Description: "text",
+	})
+
+	if !result.IsError {
+		t.Fatal("expected an error result when field_path is missing")
+	}
+	if text := resultText(result); !strings.Contains(text, "field_path") {
+		t.Errorf("error should name field_path, got %q", text)
+	}
+}

--- a/pkg/tools/write_update_handlers.go
+++ b/pkg/tools/write_update_handlers.go
@@ -31,10 +31,34 @@ func resolveTargetURN(input UpdateInput) (string, error) {
 	return input.Value, nil
 }
 
+// resolveDescription returns the text of a description update (what:
+// description, what: column_description). value is authoritative; description is
+// accepted when value is empty, since description is a real field for other what
+// values (query, incident, structured_property) and the schema therefore admits
+// it here. When both are set they must agree. Both empty is refused rather than
+// written: an empty description erases the text the target already carried, and
+// the response would still report "updated" (#194).
+func resolveDescription(input UpdateInput) (string, error) {
+	if input.Value != "" && input.Description != "" && input.Value != input.Description {
+		return "", errDescriptionConflict(input.Value, input.Description)
+	}
+	if input.Value != "" {
+		return input.Value, nil
+	}
+	if input.Description == "" {
+		return "", errRequired("value (the description text)")
+	}
+	return input.Description, nil
+}
+
 func (t *Toolkit) handleUpdateDescription(
 	ctx context.Context, c DataHubClient, input UpdateInput,
 ) (UpdateOutput, error) {
-	if err := c.UpdateDescription(ctx, input.URN, input.Value); err != nil {
+	description, err := resolveDescription(input)
+	if err != nil {
+		return UpdateOutput{}, err
+	}
+	if err := c.UpdateDescription(ctx, input.URN, description); err != nil {
 		return UpdateOutput{}, err
 	}
 	aspectName := "unknown"
@@ -52,7 +76,11 @@ func (t *Toolkit) handleUpdateColumnDescription(
 	if input.FieldPath == "" {
 		return UpdateOutput{}, errRequired("field_path")
 	}
-	if err := c.UpdateColumnDescription(ctx, input.URN, input.FieldPath, input.Value); err != nil {
+	description, err := resolveDescription(input)
+	if err != nil {
+		return UpdateOutput{}, err
+	}
+	if err := c.UpdateColumnDescription(ctx, input.URN, input.FieldPath, description); err != nil {
 		return UpdateOutput{}, err
 	}
 	return UpdateOutput{URN: input.URN, What: "column_description", Action: "updated"}, nil


### PR DESCRIPTION
Closes #194

## What this changes

`datahub_update` with `what: description` or `what: column_description` reads the new text from `value`. The same input schema also exposes `description`, which is the field `what: query`, `incident`, and `structured_property` use. Text passed as `description` therefore left `value` empty, and the handler wrote an empty string while answering `{"action":"updated"}`.

The empty write is destructive rather than inert: `editableFieldInfo.Description` is `omitempty` (`pkg/client/write.go:116`), so the field entry is rewritten without a description and the column's existing text is gone. Verified against a DataHub v1.6.0 GMS: a column documented by one call read back as `{"fieldPath": "order_id"}` after a second call whose text went to `description`.

Both handlers now resolve the text through `resolveDescription`:

- `value` is authoritative.
- `description` is used when `value` is empty.
- Both set and different is rejected, mirroring how `resolveTargetURN` treats `target_urn` vs `value`.
- Neither set is refused with `value (the description text) parameter is required`.

`field_path` validation stays ahead of the text check for `column_description`, so a call missing both is told the more specific problem.

## Behaviour change

A description update carrying no text is now an error instead of a write. `datahub_update what=description value=""` previously cleared an entity's description; that path is gone. Clearing by omission is indistinguishable from the misdirected-field case that motivates this change, and the misdirected case silently destroys text.

## Documentation

`docs/server/tools.md` states which of `value` and `description` each `what` uses, and both parameter descriptions in the tool schema say the same.

## Verification

`make verify` green: lint 0 issues, tests pass, coverage and patch coverage met, gosec 0 issues, govulncheck clean, schema check, deadcode, build.

New tests in `pkg/tools/write_update_description_test.go` cover text arriving in `description` for both `what` values, `value` winning when both agree, rejection on conflict, refusal when neither carries text, and `field_path` precedence. Each fails against the pre-fix handler.
